### PR TITLE
Remove pressable state from clickables

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -37,6 +37,6 @@ jobs:
 
       - name: Run check
         env:
-          GH_PACKAGES_USER: ${{ github.actor }}
+          GH_PACKAGES_USER: ${{ secrets.GH_CI_USER }}
           GH_PACKAGES_TOKEN: ${{ secrets.GH_CI_TOKEN }}
         run: ./gradlew check --stacktrace

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,7 +1,7 @@
 name: PR Check
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main]
 
 permissions:
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v4
@@ -36,5 +38,5 @@ jobs:
       - name: Run check
         env:
           GH_PACKAGES_USER: ${{ github.actor }}
-          GH_PACKAGES_TOKEN: ${{ secrets.GH_CI_TOKEN }}
+          GH_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./gradlew check --stacktrace

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -38,5 +38,5 @@ jobs:
       - name: Run check
         env:
           GH_PACKAGES_USER: ${{ github.actor }}
-          GH_PACKAGES_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_PACKAGES_TOKEN: ${{ secrets.GH_CI_TOKEN }}
         run: ./gradlew check --stacktrace

--- a/examples/authenticator/src/main/kotlin/com/thelightphone/authenticator/AuthenticatorHomeScreen.kt
+++ b/examples/authenticator/src/main/kotlin/com/thelightphone/authenticator/AuthenticatorHomeScreen.kt
@@ -1,7 +1,6 @@
 package com.thelightphone.authenticator
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -28,6 +27,7 @@ import com.thelightphone.sdk.ui.LightThemeTokens
 import com.thelightphone.sdk.ui.LightTopBar
 import com.thelightphone.sdk.ui.LightTopBarCenter
 import com.thelightphone.sdk.ui.gridUnitsAsDp
+import com.thelightphone.sdk.ui.lightClickable
 
 @InitialScreen
 class AuthenticatorHomeScreen(sealedActivity: SealedLightActivity) :
@@ -86,7 +86,7 @@ class AuthenticatorHomeScreen(sealedActivity: SealedLightActivity) :
                             AccountListRow(
                                 account = account,
                                 modifier = Modifier
-                                    .clickable {
+                                    .lightClickable {
                                         navigateTo(screenFactory = {
                                             AuthenticatorCodeScreen(
                                                 it,

--- a/examples/ui-demo/src/main/kotlin/com/thelightphone/uidemo/UiDemoHomeScreen.kt
+++ b/examples/ui-demo/src/main/kotlin/com/thelightphone/uidemo/UiDemoHomeScreen.kt
@@ -1,7 +1,6 @@
 package com.thelightphone.uidemo
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -26,6 +25,7 @@ import com.thelightphone.sdk.ui.LightThemeTokens
 import com.thelightphone.sdk.ui.LightTopBar
 import com.thelightphone.sdk.ui.LightTopBarCenter
 import com.thelightphone.sdk.ui.gridUnitsAsDp
+import com.thelightphone.sdk.ui.lightClickable
 
 @InitialScreen
 class UiDemoHomeScreen(sealedActivity: SealedLightActivity) :
@@ -56,28 +56,28 @@ class UiDemoHomeScreen(sealedActivity: SealedLightActivity) :
                             text = "OPEN COUNTER",
                             variant = LightTextVariant.Copy,
                             modifier = Modifier
-                                .clickable { navigateTo(::UiDemoSecondScreen) }
+                                .lightClickable { navigateTo(::UiDemoSecondScreen) }
                                 .padding(vertical = 0.75f.gridUnitsAsDp()),
                         )
                         LightText(
                             text = "SCROLLING DEMO",
                             variant = LightTextVariant.Copy,
                             modifier = Modifier
-                                .clickable { navigateTo(::UiDemoScrollScreen) }
+                                .lightClickable { navigateTo(::UiDemoScrollScreen) }
                                 .padding(vertical = 0.75f.gridUnitsAsDp()),
                         )
                         LightText(
                             text = "TEXT INPUT",
                             variant = LightTextVariant.Copy,
                             modifier = Modifier
-                                .clickable { navigateTo(::UiDemoTextInputScreen) }
+                                .lightClickable { navigateTo(::UiDemoTextInputScreen) }
                                 .padding(vertical = 0.75f.gridUnitsAsDp()),
                         )
                         LightText(
                             text = "QR CODE SCANNER",
                             variant = LightTextVariant.Copy,
                             modifier = Modifier
-                                .clickable {
+                                .lightClickable {
                                     navigateTo(
                                         screenFactory = ::UiDemoQrScannerScreen,
                                         resultCallback = { scannedResult ->
@@ -96,21 +96,21 @@ class UiDemoHomeScreen(sealedActivity: SealedLightActivity) :
                             text = "MODAL DEMO",
                             variant = LightTextVariant.Copy,
                             modifier = Modifier
-                                .clickable { showModal = true }
+                                .lightClickable { showModal = true }
                                 .padding(vertical = 0.75f.gridUnitsAsDp()),
                         )
                         LightText(
                             text = "ICONS",
                             variant = LightTextVariant.Copy,
                             modifier = Modifier
-                                .clickable { navigateTo(::UiDemoIconsScreen) }
+                                .lightClickable { navigateTo(::UiDemoIconsScreen) }
                                 .padding(vertical = 0.75f.gridUnitsAsDp()),
                         )
                         LightText(
                             text = "REVERSE THEME",
                             variant = LightTextVariant.Copy,
                             modifier = Modifier
-                                .clickable { LightThemeController.toggle() }
+                                .lightClickable { LightThemeController.toggle() }
                                 .padding(vertical = 0.75f.gridUnitsAsDp()),
                         )
                     }

--- a/examples/ui-demo/src/main/kotlin/com/thelightphone/uidemo/UiDemoSecondScreen.kt
+++ b/examples/ui-demo/src/main/kotlin/com/thelightphone/uidemo/UiDemoSecondScreen.kt
@@ -1,7 +1,6 @@
 package com.thelightphone.uidemo
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -24,6 +23,7 @@ import com.thelightphone.sdk.ui.LightThemeTokens
 import com.thelightphone.sdk.ui.LightTopBar
 import com.thelightphone.sdk.ui.LightTopBarCenter
 import com.thelightphone.sdk.ui.gridUnitsAsDp
+import com.thelightphone.sdk.ui.lightClickable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -75,7 +75,7 @@ class UiDemoSecondScreen(sealedActivity: SealedLightActivity) :
                         text = "+ INCREMENT",
                         variant = LightTextVariant.Copy,
                         modifier = Modifier
-                            .clickable { viewModel.increment() }
+                            .lightClickable { viewModel.increment() }
                             .padding(vertical = 0.75f.gridUnitsAsDp()),
                     )
                 }

--- a/examples/weather/src/main/kotlin/com/thelightphone/weather/WeatherHomeScreen.kt
+++ b/examples/weather/src/main/kotlin/com/thelightphone/weather/WeatherHomeScreen.kt
@@ -1,7 +1,6 @@
 package com.thelightphone.weather
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -51,6 +50,7 @@ import com.thelightphone.sdk.ui.LightThemeTokens
 import com.thelightphone.sdk.ui.LightTopBar
 import com.thelightphone.sdk.ui.LightTopBarCenter
 import com.thelightphone.sdk.ui.gridUnitsAsDp
+import com.thelightphone.sdk.ui.lightClickable
 import com.thelightphone.sdk.ui.verticalGridUnitsAsDp
 
 @InitialScreen
@@ -523,7 +523,7 @@ private fun SelectSettingRow(
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .clickable(onClick = onClick)
+            .lightClickable(onClick = onClick)
             .padding(vertical = 0.75f.gridUnitsAsDp()),
     ) {
         LightText(

--- a/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightBarButton.kt
+++ b/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightBarButton.kt
@@ -1,7 +1,6 @@
 package com.thelightphone.sdk.ui
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
@@ -72,7 +71,7 @@ internal fun LightBarButtonView(
     }
 
     val baseModifier = Modifier.let { modifier ->
-        if (button.onClick != null) modifier.clickable { button.onClick?.invoke() } else modifier
+        if (button.onClick != null) modifier.lightClickable { button.onClick?.invoke() } else modifier
     }
 
     when (button) {

--- a/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightClickable.kt
+++ b/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightClickable.kt
@@ -1,0 +1,22 @@
+package com.thelightphone.sdk.ui
+
+import androidx.compose.foundation.clickable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
+
+/**
+ * Makes content clickable without displaying a visual press indication.
+ */
+fun Modifier.lightClickable(
+    enabled: Boolean = true,
+    onClickLabel: String? = null,
+    role: Role? = null,
+    onClick: () -> Unit,
+): Modifier = clickable(
+    interactionSource = null,
+    indication = null,
+    enabled = enabled,
+    onClickLabel = onClickLabel,
+    role = role,
+    onClick = onClick,
+)

--- a/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightTextField.kt
+++ b/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightTextField.kt
@@ -1,7 +1,6 @@
 package com.thelightphone.sdk.ui
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -40,7 +39,7 @@ fun LightTextField(
         Column(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable(onClick = onClick)
+                .lightClickable(onClick = onClick)
                 .padding(top = 0.25f.gridUnitsAsDp()),
         ) {
             LightText(

--- a/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightTopBar.kt
+++ b/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightTopBar.kt
@@ -1,6 +1,5 @@
 package com.thelightphone.sdk.ui
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -104,7 +103,7 @@ private fun LightTopBarCenterView(center: LightTopBarCenter?) {
 
     val modifier = Modifier
         .widthIn(max = CENTER_MAX_WIDTH_UNITS.gridUnitsAsDp())
-        .let { m -> if (center.onClick != null) m.clickable { center.onClick?.invoke() } else m }
+        .let { m -> if (center.onClick != null) m.lightClickable { center.onClick?.invoke() } else m }
 
     when (center) {
         is LightTopBarCenter.Text -> {

--- a/tool/src/main/kotlin/com/thelightphone/sample/DetailScreen.kt
+++ b/tool/src/main/kotlin/com/thelightphone/sample/DetailScreen.kt
@@ -1,7 +1,6 @@
 package com.thelightphone.sample
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -18,6 +17,7 @@ import com.thelightphone.sdk.LightScreen
 import com.thelightphone.sdk.LightViewModel
 import com.thelightphone.sdk.SealedLightActivity
 import com.thelightphone.sdk.SimpleLightScreen
+import com.thelightphone.sdk.ui.lightClickable
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.okhttp.OkHttp
@@ -111,7 +111,7 @@ class DetailScreen(sealedActivity: SealedLightActivity) :
                 text = "Go Back",
                 modifier = Modifier
                     .padding(top = 16.dp)
-                    .clickable { goBack() },
+                    .lightClickable { goBack() },
             )
         }
     }

--- a/tool/src/main/kotlin/com/thelightphone/sample/HomeScreen.kt
+++ b/tool/src/main/kotlin/com/thelightphone/sample/HomeScreen.kt
@@ -2,7 +2,6 @@ package com.thelightphone.sample
 
 import android.util.Log
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
@@ -30,6 +29,7 @@ import com.thelightphone.sdk.ui.LightTextVariant
 import com.thelightphone.sdk.ui.LightTheme
 import com.thelightphone.sdk.ui.LightThemeController
 import com.thelightphone.sdk.ui.LightThemeTokens
+import com.thelightphone.sdk.ui.lightClickable
 import com.thelightphone.sdk.shared.LightServiceMethod
 import com.thelightphone.sdk.shared.error
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -97,7 +97,7 @@ class HomeScreen(sealedActivity: SealedLightActivity) : LightScreen<Unit, HomeSc
                         icon = LightIcons.SETTINGS,
                         modifier = Modifier
                             .padding(end = 16.dp)
-                            .clickable { LightThemeController.toggle() },
+                            .lightClickable { LightThemeController.toggle() },
                     )
                     LightIcon(icon = LightIcons.CALL, modifier = Modifier.padding(end = 16.dp))
                     LightIcon(icon = LightIcons.SEARCH, modifier = Modifier.padding(end = 16.dp))
@@ -127,7 +127,7 @@ class HomeScreen(sealedActivity: SealedLightActivity) : LightScreen<Unit, HomeSc
                                 variant = LightTextVariant.Copy,
                                 modifier = Modifier
                                     .fillMaxWidth()
-                                    .clickable { viewModel.selectRingtone(filename) }
+                                    .lightClickable { viewModel.selectRingtone(filename) }
                                     .padding(vertical = 12.dp),
                             )
                         }


### PR DESCRIPTION
Fixes #30.

I have created a new `lightClickable` modifier to take place of the default `clickable` one! It should keep the click and accessibility behaviour but just removes the press indication.

I've updated the toolbar buttons and clickable stuff in the UI demo and examples.

## Before
<img width="300" alt="Before Example" src="https://github.com/user-attachments/assets/64ba111e-09fd-457e-bee4-ff58afaff5db" />

## After
<img width="300" alt="After Example" src="https://github.com/user-attachments/assets/a25d64ac-35d9-46fb-a6ed-2ec9ae12596e" />
