### PR TITLE
Preserve location search 

### DIFF
--- a/examples/weather/src/main/kotlin/com/thelightphone/weather/WeatherHomeScreen.kt
+++ b/examples/weather/src/main/kotlin/com/thelightphone/weather/WeatherHomeScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.material3.Text
@@ -66,7 +67,6 @@ class WeatherHomeScreen(sealedActivity: SealedLightActivity) :
     override fun Content() {
         val themeColors by LightThemeController.colors.collectAsState()
         val state by viewModel.uiState.collectAsState()
-        val textFieldState = rememberTextFieldState("")
         val keyboardOptionsFlow = rememberKeyboardOptions()
         LightTheme(colors = themeColors) {
             Box(
@@ -76,17 +76,21 @@ class WeatherHomeScreen(sealedActivity: SealedLightActivity) :
             ) {
                 when (val mode = state.mode) {
                     is WeatherScreenMode.LocationInput -> {
-                        LightTextInputEditor(
-                            title = "Search Location",
-                            editorKey = state.locationInputSession,
-                            keyboardOptionsFlow = keyboardOptionsFlow,
-                            state = textFieldState,
-                            onSubmit = viewModel::submitLocation,
-                            onBack = viewModel::cancelLocationInput,
-                            submitIcon = LightIcons.SEARCH,
-                            showBackButton = state.canCancelLocationInput,
-                            modifier = Modifier.fillMaxSize(),
-                        )
+                        key(state.locationInputSession) {
+                            val textFieldState = rememberTextFieldState(state.locationInputQuery)
+                            LightTextInputEditor(
+                                title = "Search Location",
+                                editorKey = state.locationInputSession,
+                                keyboardOptionsFlow = keyboardOptionsFlow,
+                                state = textFieldState,
+                                onSubmit = viewModel::submitLocation,
+                                onBack = viewModel::cancelLocationInput,
+                                onTextChanged = viewModel::updateLocationInputQuery,
+                                submitIcon = LightIcons.SEARCH,
+                                showBackButton = state.canCancelLocationInput,
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                        }
                     }
 
                     is WeatherScreenMode.Loading -> {

--- a/examples/weather/src/main/kotlin/com/thelightphone/weather/WeatherViewModel.kt
+++ b/examples/weather/src/main/kotlin/com/thelightphone/weather/WeatherViewModel.kt
@@ -44,6 +44,7 @@ data class WeatherUiState(
     val mode: WeatherScreenMode = WeatherScreenMode.Loading,
     val canCancelLocationInput: Boolean = false,
     val locationInputSession: Int = 0,
+    val locationInputQuery: String = "",
     val temperatureUnit: TemperatureUnit = TemperatureUnit.Celsius,
     val errorModal: String? = null,
 )
@@ -86,6 +87,7 @@ class WeatherViewModel(
         mode = WeatherScreenMode.LocationInput,
         canCancelLocationInput = canCancel,
         locationInputSession = locationInputSession + 1,
+        locationInputQuery = locationInputQuery.ifBlank { savedLocationQuery },
         errorModal = null,
     )
 
@@ -174,6 +176,7 @@ class WeatherViewModel(
                         forecast = cachedForecast,
                     ),
                     canCancelLocationInput = true,
+                    locationInputQuery = query,
                     temperatureUnit = unit,
                 ),
             )
@@ -211,6 +214,7 @@ class WeatherViewModel(
             return
         }
 
+        _uiState.update { it.copy(locationInputQuery = query) }
         viewModelScope.launch(Dispatchers.IO + apiExceptionHandler) {
             runCatching {
                 updateState {
@@ -276,6 +280,7 @@ class WeatherViewModel(
                             selectedDayIndex = lastSelectedDayIndex,
                         ),
                         canCancelLocationInput = true,
+                        locationInputQuery = query,
                     )
                 }
             },
@@ -384,6 +389,10 @@ class WeatherViewModel(
         _uiState.update { it.openLocationInput(canCancel = true) }
     }
 
+    fun updateLocationInputQuery(query: String) {
+        _uiState.update { it.copy(locationInputQuery = query) }
+    }
+
     fun toggleTemperatureUnit() {
         val next = _uiState.value.temperatureUnit.toggle()
         _uiState.update { it.copy(temperatureUnit = next) }
@@ -463,6 +472,7 @@ class WeatherViewModel(
                         selectedDayIndex = lastSelectedDayIndex,
                     ),
                     canCancelLocationInput = true,
+                    locationInputQuery = query,
                     temperatureUnit = _uiState.value.temperatureUnit,
                     errorModal = errorMessage,
                 ),

--- a/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightTextInputEditor.kt
+++ b/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightTextInputEditor.kt
@@ -14,6 +14,8 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -48,6 +50,7 @@ fun LightTextInputEditor(
     submitIcon: LightIconConfiguration? = null,
     showBackButton: Boolean = true,
     editorKey: Any = title,
+    onTextChanged: (String) -> Unit = {},
 ) {
     val keyboardCallback = remember(state) { TextInputKeyboardCallback(state) }
 
@@ -66,6 +69,7 @@ fun LightTextInputEditor(
         submitLabel,
         submitIcon,
         showBackButton,
+        onTextChanged,
     )
 }
 
@@ -87,10 +91,16 @@ fun LightTextInputEditor(
     submitLabel: String = "SUBMIT",
     submitIcon: LightIconConfiguration? = null,
     showBackButton: Boolean = true,
+    onTextChanged: (String) -> Unit = {},
 ) {
     val colors = LightThemeTokens.colors
     val inputStyle = lightInputTextStyle()
     var textLayout by remember { mutableStateOf<TextLayoutResult?>(null) }
+    val onTextChangedState by rememberUpdatedState(onTextChanged)
+
+    LaunchedEffect(state) {
+        snapshotFlow { state.text.toString() }.collect { onTextChangedState(it) }
+    }
 
     Surface {
         Column(modifier = modifier.fillMaxSize()) {


### PR DESCRIPTION
## Summary

- Preserve the in-progress location search query when backing out of the Weather search editor.
- Initialize each new search editor session from the cached draft or saved location query.
- Add an optional `LightTextInputEditor` text-change callback so callers can cache draft input without changing existing behavior.

## Root Cause

The Weather example created its `TextFieldState` with an empty initial value outside the location-input branch, so reopening the search editor after back/cancel started from a blank draft instead of the previous entry.

## Validation

- `git diff --check`
- Attempted `C:\repos\personal\light-sdk\gradlew.bat :sdk:ui:compileDebugKotlin :examples:weather:compileDebugKotlin --stacktrace`, but local validation was blocked because `JAVA_HOME` is unset and no `java` executable is on `PATH`.