### PR TITLE
Draggable Scrollbar Thumbs

### DIFF
--- a/examples/ui-demo/src/main/kotlin/com/thelightphone/uidemo/UiDemoIconsScreen.kt
+++ b/examples/ui-demo/src/main/kotlin/com/thelightphone/uidemo/UiDemoIconsScreen.kt
@@ -71,7 +71,10 @@ class UiDemoIconsScreen(sealedActivity: SealedLightActivity) :
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxWidth()
-                        .padding(start = 1f.gridUnitsAsDp()),
+                        .padding(
+                            start = 1f.gridUnitsAsDp(),
+                            bottom = 1f.gridUnitsAsDp(),
+                        ),
                     uniformItemHeightGridUnits = ICON_GALLERY_ROW_HEIGHT_GRID,
                 ) {
                     items(icons, key = { it.first }) { (id, icon) ->

--- a/examples/ui-demo/src/main/kotlin/com/thelightphone/uidemo/UiDemoScrollScreen.kt
+++ b/examples/ui-demo/src/main/kotlin/com/thelightphone/uidemo/UiDemoScrollScreen.kt
@@ -59,7 +59,10 @@ class UiDemoScrollScreen(sealedActivity: SealedLightActivity) :
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxWidth()
-                        .padding(start = 1f.gridUnitsAsDp()),
+                        .padding(
+                            start = 1f.gridUnitsAsDp(),
+                            bottom = 1f.gridUnitsAsDp(),
+                        ),
                 ) {
                     repeat(DEMO_ROW_COUNT) { index ->
                         LightText(

--- a/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightScrollView.kt
+++ b/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightScrollView.kt
@@ -67,7 +67,7 @@ private data class LightScrollBarGeometry(
     val thumbOffsetPx = contentScrollFraction * maxThumbOffsetPx
 
     fun containsTouchX(xPx: Float): Boolean =
-        xPx >= touchLeftPx && xPx <= touchRightPx
+        xPx in touchLeftPx..touchRightPx
 
     fun containsThumb(xPx: Float, yPx: Float): Boolean =
         containsTouchX(xPx) &&
@@ -88,6 +88,7 @@ fun LightScrollView(
 ) {
     val scrollState = rememberScrollState()
     val scope = rememberCoroutineScope()
+    val scrollOffsetPx by remember { derivedStateOf { scrollState.value.toFloat() } }
     val showScrollBar = scrollState.maxValue > 0
     val contentPaddingEnd = when {
         !showScrollBar -> 0f
@@ -105,7 +106,7 @@ fun LightScrollView(
             )
             if (showScrollBar) {
                 LightScrollBar(
-                    contentScrollOffsetPx = scrollState.value.toFloat(),
+                    contentScrollOffsetPx = scrollOffsetPx,
                     maxContentScrollOffsetPx = scrollState.maxValue.toFloat(),
                     onScrollTo = { target ->
                         scope.launch { scrollState.scrollTo(target.roundToInt()) }
@@ -131,7 +132,7 @@ fun LightScrollView(
             )
             if (showScrollBar) {
                 LightScrollBar(
-                    contentScrollOffsetPx = scrollState.value.toFloat(),
+                    contentScrollOffsetPx = scrollOffsetPx,
                     maxContentScrollOffsetPx = scrollState.maxValue.toFloat(),
                     onScrollTo = { target ->
                         scope.launch { scrollState.scrollTo(target.roundToInt()) }
@@ -243,7 +244,7 @@ private fun LightScrollBar(
     val trackWidth = SCROLLBAR_WIDTH_UNITS.gridUnitsAsDp()
     val railWidth = 1.dp
     val thumbWidth = 5.dp
-    val touchWidth = thumbWidth * 5
+    val touchWidth = thumbWidth * 6
 
     BoxWithConstraints(
         modifier = modifier.width(trackWidth),

--- a/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightScrollView.kt
+++ b/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightScrollView.kt
@@ -335,7 +335,16 @@ private fun LightScrollBar(
 @Composable
 private fun PreviewLightScrollViewDark() {
     LightTheme(colors = LightThemeColors.Dark) {
-        LightScrollView(modifier = Modifier.fillMaxSize()) {
+        LightScrollView(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(color = LightThemeTokens.colors.background)
+                .padding(
+                    top = 1f.gridUnitsAsDp(),
+                    start = 1f.gridUnitsAsDp(),
+                    bottom = 1f.gridUnitsAsDp(),
+                ),
+            ) {
             repeat(24) { index ->
                 LightText(
                     text = "Scrollable row ${index + 1}",

--- a/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightScrollView.kt
+++ b/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightScrollView.kt
@@ -1,8 +1,10 @@
 package com.thelightphone.sdk.ui
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
 import androidx.compose.foundation.gestures.detectTapGestures
-import androidx.compose.foundation.gestures.detectVerticalDragGestures
+import androidx.compose.foundation.gestures.drag
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
@@ -26,6 +28,7 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
@@ -37,13 +40,44 @@ import kotlin.math.roundToInt
 
 private const val SCROLLBAR_WIDTH_UNITS = 2f
 private const val SCROLLBAR_INSIDE_VERTICAL_PADDING_UNITS = 1f
-private const val MIN_HANDLE_FRACTION = 0.1f
-private const val MAX_HANDLE_FRACTION = 0.85f
+private const val MIN_THUMB_FRACTION = 0.1f
+private const val MAX_THUMB_FRACTION = 0.85f
 
 enum class LightScrollBarPosition {
     Outside,
 
     Inside,
+}
+
+private data class LightScrollBarGeometry(
+    val trackWidthPx: Float,
+    val trackHeightPx: Float,
+    val touchWidthPx: Float,
+    val contentScrollOffsetPx: Float,
+    val maxContentScrollOffsetPx: Float,
+) {
+    private val contentHeightPx = trackHeightPx + maxContentScrollOffsetPx
+    private val visibleContentFraction = trackHeightPx / contentHeightPx
+    private val contentScrollFraction = (contentScrollOffsetPx / maxContentScrollOffsetPx).coerceIn(0f, 1f)
+    private val touchLeftPx = (trackWidthPx - touchWidthPx) / 2f
+    private val touchRightPx = touchLeftPx + touchWidthPx
+
+    val thumbHeightPx = trackHeightPx * visibleContentFraction.coerceIn(MIN_THUMB_FRACTION, MAX_THUMB_FRACTION)
+    val maxThumbOffsetPx = trackHeightPx - thumbHeightPx
+    val thumbOffsetPx = contentScrollFraction * maxThumbOffsetPx
+
+    fun containsTouchX(xPx: Float): Boolean =
+        xPx >= touchLeftPx && xPx <= touchRightPx
+
+    fun containsThumb(xPx: Float, yPx: Float): Boolean =
+        containsTouchX(xPx) &&
+            yPx >= thumbOffsetPx &&
+            yPx <= thumbOffsetPx + thumbHeightPx
+
+    fun contentScrollOffsetToPlaceThumbTopAt(thumbTopPx: Float): Float {
+        val fraction = (thumbTopPx / maxThumbOffsetPx).coerceIn(0f, 1f)
+        return fraction * maxContentScrollOffsetPx
+    }
 }
 
 @Composable
@@ -71,8 +105,8 @@ fun LightScrollView(
             )
             if (showScrollBar) {
                 LightScrollBar(
-                    scrollValue = scrollState.value.toFloat(),
-                    maxScrollValue = scrollState.maxValue.toFloat(),
+                    contentScrollOffsetPx = scrollState.value.toFloat(),
+                    maxContentScrollOffsetPx = scrollState.maxValue.toFloat(),
                     onScrollTo = { target ->
                         scope.launch { scrollState.scrollTo(target.roundToInt()) }
                     },
@@ -97,8 +131,8 @@ fun LightScrollView(
             )
             if (showScrollBar) {
                 LightScrollBar(
-                    scrollValue = scrollState.value.toFloat(),
-                    maxScrollValue = scrollState.maxValue.toFloat(),
+                    contentScrollOffsetPx = scrollState.value.toFloat(),
+                    maxContentScrollOffsetPx = scrollState.maxValue.toFloat(),
                     onScrollTo = { target ->
                         scope.launch { scrollState.scrollTo(target.roundToInt()) }
                     },
@@ -163,8 +197,8 @@ fun LightLazyScrollView(
             )
             if (showScrollBar) {
                 LightScrollBar(
-                    scrollValue = scrollPx,
-                    maxScrollValue = maxScrollPx,
+                    contentScrollOffsetPx = scrollPx,
+                    maxContentScrollOffsetPx = maxScrollPx,
                     onScrollTo = ::scrollToOffsetPx,
                     modifier = Modifier
                         .align(Alignment.CenterEnd)
@@ -187,8 +221,8 @@ fun LightLazyScrollView(
             )
             if (showScrollBar) {
                 LightScrollBar(
-                    scrollValue = scrollPx,
-                    maxScrollValue = maxScrollPx,
+                    contentScrollOffsetPx = scrollPx,
+                    maxContentScrollOffsetPx = maxScrollPx,
                     onScrollTo = ::scrollToOffsetPx,
                     modifier = Modifier.fillMaxHeight(),
                 )
@@ -199,8 +233,8 @@ fun LightLazyScrollView(
 
 @Composable
 private fun LightScrollBar(
-    scrollValue: Float,
-    maxScrollValue: Float,
+    contentScrollOffsetPx: Float,
+    maxContentScrollOffsetPx: Float,
     onScrollTo: (Float) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -208,7 +242,8 @@ private fun LightScrollBar(
     val density = LocalDensity.current
     val trackWidth = SCROLLBAR_WIDTH_UNITS.gridUnitsAsDp()
     val railWidth = 1.dp
-    val handleWidth = 5.dp
+    val thumbWidth = 5.dp
+    val touchWidth = thumbWidth * 5
 
     BoxWithConstraints(
         modifier = modifier.width(trackWidth),
@@ -217,34 +252,56 @@ private fun LightScrollBar(
         val trackHeightPx = with(density) { maxHeight.toPx() }
         if (trackHeightPx <= 0f) return@BoxWithConstraints
 
-        val viewportHeightPx = trackHeightPx
-        val contentHeightPx = viewportHeightPx + maxScrollValue
-        val handleHeightFraction = (viewportHeightPx / contentHeightPx)
-            .coerceIn(MIN_HANDLE_FRACTION, MAX_HANDLE_FRACTION)
-        val handleHeightPx = trackHeightPx * handleHeightFraction
-        val availableScrollRoomPx = trackHeightPx - handleHeightPx
-        val scrollFraction = if (maxScrollValue > 0f) {
-            (scrollValue / maxScrollValue).coerceIn(0f, 1f)
-        } else {
-            0f
-        }
-        val handleOffsetPx = scrollFraction * availableScrollRoomPx
-        val handleOffsetDp = with(density) { handleOffsetPx.toDp() }
-        val handleHeightDp = with(density) { handleHeightPx.toDp() }
+        val geometry = LightScrollBarGeometry(
+            trackWidthPx = with(density) { trackWidth.toPx() },
+            trackHeightPx = trackHeightPx,
+            touchWidthPx = with(density) { touchWidth.toPx() },
+            contentScrollOffsetPx = contentScrollOffsetPx,
+            maxContentScrollOffsetPx = maxContentScrollOffsetPx,
+        )
+        val thumbOffsetDp = with(density) { geometry.thumbOffsetPx.toDp() }
+        val thumbHeightDp = with(density) { geometry.thumbHeightPx.toDp() }
+        val currentOnScrollTo by rememberUpdatedState(onScrollTo)
+        val currentGeometry by rememberUpdatedState(geometry)
 
-        fun scrollToTrackOffset(yPx: Float) {
-            val totalScrollable = contentHeightPx - viewportHeightPx
-            if (totalScrollable <= 0f) return
-            val fraction = (yPx / trackHeightPx).coerceIn(0f, 1f)
-            onScrollTo(fraction * totalScrollable)
+        fun handleTrackTap(xPx: Float, yPx: Float) {
+            val geometry = currentGeometry
+            if (!geometry.containsTouchX(xPx)) return
+            if (geometry.containsThumb(xPx, yPx)) return
+
+            val targetThumbTopPx = yPx - geometry.thumbHeightPx / 2f
+            currentOnScrollTo(geometry.contentScrollOffsetToPlaceThumbTopAt(targetThumbTopPx))
         }
 
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .pointerInput(maxScrollValue, scrollValue) {
+                .pointerInput(Unit) {
+                    awaitEachGesture {
+                        val down = awaitFirstDown(requireUnconsumed = false)
+                        val startGeometry = currentGeometry
+                        if (!startGeometry.containsThumb(down.position.x, down.position.y)) {
+                            return@awaitEachGesture
+                        }
+
+                        down.consume()
+                        val dragStartThumbOffsetPx = startGeometry.thumbOffsetPx
+                        var dragAmountPx = 0f
+
+                        drag(down.id) { change ->
+                            change.consume()
+                            val geometry = currentGeometry
+
+                            dragAmountPx += change.position.y - change.previousPosition.y
+                            val newThumbTop = (dragStartThumbOffsetPx + dragAmountPx)
+                                .coerceIn(0f, geometry.maxThumbOffsetPx)
+                            currentOnScrollTo(geometry.contentScrollOffsetToPlaceThumbTopAt(newThumbTop))
+                        }
+                    }
+                }
+                .pointerInput(Unit) {
                     detectTapGestures { offset ->
-                        scrollToTrackOffset(offset.y)
+                        handleTrackTap(offset.x, offset.y)
                     }
                 },
         ) {
@@ -258,30 +315,18 @@ private fun LightScrollBar(
             Box(
                 modifier = Modifier
                     .align(Alignment.TopCenter)
-                    .offset(y = handleOffsetDp)
-                    .width(handleWidth)
-                    .height(handleHeightDp)
-                    .background(barColor)
-                    .pointerInput(maxScrollValue, scrollValue) {
-                        var dragStartHandleOffsetPx = 0f
-                        detectVerticalDragGestures(
-                            onDragStart = {
-                                dragStartHandleOffsetPx = handleOffsetPx
-                            },
-                            onVerticalDrag = { change, dragAmount ->
-                                change.consume()
-                                if (availableScrollRoomPx <= 0f || maxScrollValue <= 0f) {
-                                    return@detectVerticalDragGestures
-                                }
-                                val totalScrollable = contentHeightPx - viewportHeightPx
-                                val newHandleTop = (dragStartHandleOffsetPx + dragAmount)
-                                    .coerceIn(0f, availableScrollRoomPx)
-                                val newScroll = (newHandleTop / availableScrollRoomPx) * totalScrollable
-                                onScrollTo(newScroll)
-                            },
-                        )
-                    },
-            )
+                    .offset(y = thumbOffsetDp)
+                    .width(trackWidth)
+                    .height(thumbHeightDp),
+                contentAlignment = Alignment.Center,
+            ) {
+                Box(
+                    modifier = Modifier
+                        .width(thumbWidth)
+                        .fillMaxHeight()
+                        .background(barColor),
+                )
+            }
         }
     }
 }


### PR DESCRIPTION
For #43.

## Summary
- Scrollbar thumbs can now be dragged!
- Adjusted hitbox for tapping and dragging. It spanned quite far to the left previously. Happy to adjust this if that was done on purpose!
- Tapping on the scrollbar now places the thumb at the centre. This would only be satisfied for taps near the middle previously.

### Drag and tap demo with hitbox
<img width="300" alt="Dragging and tapping demo with hitbox" src="https://github.com/user-attachments/assets/2bc5dc90-f115-465d-9aca-e7642323917d" />

### Tapping

| Old Tap Behaviour | New Tap Behaviour |
|--------|--------|
| <img width="300" alt="Old tap behaviour" src="https://github.com/user-attachments/assets/4c5a774e-fdf9-4cd8-be31-303369019a30" /> | <img width="300" alt="New tap behaviour" src="https://github.com/user-attachments/assets/5282b26b-d2e0-4532-bacb-a34e399bd186" /> |

## AI Disclosure
- GPT-5.5 was used for the initial drag implementation.
- Personal touches: 
  - bring most of the maths into `LightScrollBarGeometry`
  - variable and fn names, happy for some feedback on this!
  - tap behaviour
  - hitbox