### PR TITLE
fix(sdk): ship consumer ProGuard rules for the SDK's reflection surface

### DIFF
--- a/examples/authenticator/build.gradle.kts
+++ b/examples/authenticator/build.gradle.kts
@@ -26,6 +26,8 @@ android {
             signingConfig = signingConfigs.getByName("lightsdkDev")
         }
         release {
+            isMinifyEnabled = true
+            proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"))
             signingConfig = signingConfigs.getByName("lightsdkDev")
         }
     }

--- a/sdk/client/build.gradle.kts
+++ b/sdk/client/build.gradle.kts
@@ -25,6 +25,7 @@ android {
     defaultConfig {
         minSdk = rootProject.ext["minSdk"] as Int
         buildConfigField("String", "LIGHT_VAPID_KEY", "\"$vapidPublicKey\"")
+        consumerProguardFiles("consumer-rules.pro")
     }
 
     buildFeatures {

--- a/sdk/client/consumer-rules.pro
+++ b/sdk/client/consumer-rules.pro
@@ -1,0 +1,12 @@
+-keep class com.thelightphone.sdk.generated.LightSdkRegistry { *; }
+-keep class com.thelightphone.sdk.generated.** { *; }
+
+-keep @com.thelightphone.sdk.InitialScreen class * { *; }
+-keep class * implements com.thelightphone.sdk.LightEntryPoint { *; }
+
+-keep class com.thelightphone.sdk.LightFileProvider { *; }
+-keep class com.thelightphone.sdk.LightPushService { *; }
+-keep class com.thelightphone.sdk.LightActivity { *; }
+-keep class com.thelightphone.sdk.SealedLightActivity { *; }
+-keep class com.thelightphone.sdk.LightSdkApplication { *; }
+-keep class com.thelightphone.sdk.LightSdkReceiver { *; }

--- a/sdk/ui/build.gradle.kts
+++ b/sdk/ui/build.gradle.kts
@@ -14,6 +14,7 @@ android {
 
     defaultConfig {
         minSdk = rootProject.ext["minSdk"] as Int
+        consumerProguardFiles("consumer-rules.pro")
     }
 
     compileOptions {

--- a/sdk/ui/consumer-rules.pro
+++ b/sdk/ui/consumer-rules.pro
@@ -1,0 +1,4 @@
+-keep class com.thelightphone.sdk.ui.LightIcons { *; }
+-keep class com.thelightphone.sdk.ui.LightIcons$* {
+    public static ** INSTANCE;
+}


### PR DESCRIPTION
Ship consumer-rules.pro from sdk:ui and sdk:client so consumers inherit the keeps automatically, and enable minification on the authenticator example, which now builds against nothing but these rules.

This would close #54.