### PR TITLE
feat(ui): single-line mode for LightTextInputEditor

### DIFF
--- a/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightTextInputEditor.kt
+++ b/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightTextInputEditor.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -47,9 +48,17 @@ fun LightTextInputEditor(
     submitLabel: String = "SUBMIT",
     submitIcon: LightIconConfiguration? = null,
     showBackButton: Boolean = true,
+    singleLine: Boolean = false,
     editorKey: Any = title,
 ) {
-    val keyboardCallback = remember(state) { TextInputKeyboardCallback(state) }
+    val currentOnSubmit by rememberUpdatedState(onSubmit)
+    val keyboardCallback = remember(state, singleLine) {
+        TextInputKeyboardCallback(
+            state = state,
+            singleLine = singleLine,
+            onReturn = { currentOnSubmit(state.text) },
+        )
+    }
 
     val keyboardViewModel: Lp3KeyboardViewModel = viewModel<DefaultLp3KeyboardViewModel>(
         key = "LightTextInputEditor-$editorKey",
@@ -66,6 +75,7 @@ fun LightTextInputEditor(
         submitLabel,
         submitIcon,
         showBackButton,
+        singleLine,
     )
 }
 
@@ -87,6 +97,7 @@ fun LightTextInputEditor(
     submitLabel: String = "SUBMIT",
     submitIcon: LightIconConfiguration? = null,
     showBackButton: Boolean = true,
+    singleLine: Boolean = false,
 ) {
     val colors = LightThemeTokens.colors
     val inputStyle = lightInputTextStyle()
@@ -138,6 +149,8 @@ fun LightTextInputEditor(
                     text = state.text.toString(),
                     style = inputStyle,
                     onTextLayout = { textLayout = it },
+                    maxLines = if (singleLine) 1 else Int.MAX_VALUE,
+                    softWrap = !singleLine,
                     modifier = Modifier.fillMaxWidth(),
                 )
                 textLayout?.let { layout ->

--- a/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightTextInputEditor.kt
+++ b/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightTextInputEditor.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.TextRange
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextDecoration
@@ -151,6 +152,7 @@ fun LightTextInputEditor(
                     onTextLayout = { textLayout = it },
                     maxLines = if (singleLine) 1 else Int.MAX_VALUE,
                     softWrap = !singleLine,
+                    overflow = if (singleLine) TextOverflow.StartEllipsis else TextOverflow.Clip,
                     modifier = Modifier.fillMaxWidth(),
                 )
                 textLayout?.let { layout ->

--- a/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/keyboard/TextInputKeyboardCallback.kt
+++ b/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/keyboard/TextInputKeyboardCallback.kt
@@ -8,6 +8,8 @@ import com.thelightphone.lp3Keyboard.ui.SpecialKey
 
 internal class TextInputKeyboardCallback(
     private val state: TextFieldState,
+    private val singleLine: Boolean = false,
+    private val onReturn: () -> Unit = {},
 ) : Lp3RepeatableKeyboardCallback {
 
     override fun onKeyPressed(code: Int) = Unit
@@ -26,7 +28,7 @@ internal class TextInputKeyboardCallback(
                 val before = state.text.subSequence(0, state.selection.min)
                 deleteBeforeCursor(surrogateAwareDeleteCount(before, 1))
             }
-            SpecialKey.Return -> insertAtCursor("\n")
+            SpecialKey.Return -> if (singleLine) onReturn() else insertAtCursor("\n")
             else -> Unit
         }
     }


### PR DESCRIPTION
Text fields for usernames, passwords, and URLs currently have no way to reject newlines: the keyboard's return key always inserts a literal `\n`, which silently corrupts the value. With singleLine = true the editor renders a single row and the return key submits (same action as the submit control) instead of inserting a newline. Default false preserves existing behavior.