### PR TITLE
feat: allow NFC + USB host for security-key tools

### DIFF
--- a/plugin/src/main/kotlin/com/thelightphone/plugin/LightToolMetadata.kt
+++ b/plugin/src/main/kotlin/com/thelightphone/plugin/LightToolMetadata.kt
@@ -141,6 +141,7 @@ object LightToolPolicy {
         "android.permission.RECORD_AUDIO",
         "android.permission.ACCESS_FINE_LOCATION",
         "android.permission.ACCESS_COARSE_LOCATION",
+        "android.permission.NFC",
     )
 
     /**
@@ -156,6 +157,7 @@ object LightToolPolicy {
         "android.permission.RECORD_AUDIO" to listOf("android.hardware.microphone"),
         "android.permission.ACCESS_FINE_LOCATION" to listOf("android.hardware.location.gps"),
         "android.permission.ACCESS_COARSE_LOCATION" to listOf("android.hardware.location.network"),
+        "android.permission.NFC" to listOf("android.hardware.nfc"),
     )
 }
 

--- a/plugin/src/test/kotlin/com/thelightphone/plugin/ManifestGeneratorTest.kt
+++ b/plugin/src/test/kotlin/com/thelightphone/plugin/ManifestGeneratorTest.kt
@@ -70,6 +70,16 @@ class ManifestGeneratorTest {
     }
 
     @Test
+    fun `nfc permission emits nfc uses-feature`() {
+        val xml = render(permissions = listOf("android.permission.NFC"))
+        assertTrue(xml.contains("""<uses-permission android:name="android.permission.NFC" />"""))
+        assertTrue(
+            xml.contains("""<uses-feature android:name="android.hardware.nfc" android:required="false" />"""),
+            "expected android.hardware.nfc uses-feature; got:\n$xml"
+        )
+    }
+
+    @Test
     fun `permission without implied feature emits no uses-feature`() {
         val xml = render(permissions = listOf("android.permission.INTERNET"))
         assertFalse(xml.contains("uses-feature"))

--- a/sdk/client/src/main/AndroidManifest.xml
+++ b/sdk/client/src/main/AndroidManifest.xml
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Lets tools talk to USB security keys / hardware tokens. required=false
+         so it never filters out devices without USB host support. -->
+    <uses-feature android:name="android.hardware.usb.host" android:required="false" />
     <application>
         <provider
             android:name="com.thelightphone.sdk.LightFileProvider"


### PR DESCRIPTION
Add android.permission.NFC to the tool permission allow-list (with its implied android.hardware.nfc uses-feature) and declare the USB host uses-feature in the client manifest, so tools can talk to NFC and USB hardware security keys.

Re #37