### PR TITLE
feat(sdk): allow READ_MEDIA_AUDIO for tools

### DIFF
--- a/plugin/src/main/kotlin/com/thelightphone/plugin/LightToolMetadata.kt
+++ b/plugin/src/main/kotlin/com/thelightphone/plugin/LightToolMetadata.kt
@@ -139,6 +139,7 @@ object LightToolPolicy {
         "android.permission.POST_NOTIFICATIONS",
         "android.permission.CAMERA",
         "android.permission.RECORD_AUDIO",
+        "android.permission.READ_MEDIA_AUDIO",
         "android.permission.ACCESS_FINE_LOCATION",
         "android.permission.ACCESS_COARSE_LOCATION",
     )

--- a/sdk/server/src/main/kotlin/com/thelightphone/sdk/server/LightSdkServer.kt
+++ b/sdk/server/src/main/kotlin/com/thelightphone/sdk/server/LightSdkServer.kt
@@ -143,8 +143,11 @@ object LightSdkServer {
      * Settable from enclosing application!! May be run on any thread
      */
     var androidPermissionAllowed: (callingUid: Int, permissionName: String) -> Boolean = { _, permissionName ->
-        // default, only allow camera for now
-        setOf(Manifest.permission.CAMERA).contains(permissionName)
+        // default grantable permissions; enclosing app may override
+        setOf(
+            Manifest.permission.CAMERA,
+            Manifest.permission.READ_MEDIA_AUDIO,
+        ).contains(permissionName)
     }
 
     var permissionActivity: Class<out Activity>? = null


### PR DESCRIPTION
As per #62
Add android.permission.READ_MEDIA_AUDIO to the tool permission allowlist (LightToolPolicy.ALLOWED_PERMISSIONS) so tools can declare it in lighttool.toml, and to the default server-grantable set (LightSdkServer.androidPermissionAllowed) so it can be granted at runtime. Enables media tools to read the on-device audio library via MediaStore.