### PR TITLE
fix(ui): prevent LightScrollView scrollbar show/hide oscillation

### DIFF
--- a/sdk/ui/build.gradle.kts
+++ b/sdk/ui/build.gradle.kts
@@ -62,4 +62,5 @@ dependencies {
     api(libs.compose.runtime)
     debugApi(libs.compose.ui.tooling)
     api(libs.compose.ui.tooling.preview)
+    testImplementation(libs.kotlin.test)
 }

--- a/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightScrollView.kt
+++ b/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightScrollView.kt
@@ -80,6 +80,14 @@ private data class LightScrollBarGeometry(
     }
 }
 
+fun scrollBarGutterUnits(position: LightScrollBarPosition): Float = when (position) {
+    LightScrollBarPosition.Outside -> SCROLLBAR_WIDTH_UNITS
+    LightScrollBarPosition.Inside -> 0f
+}
+
+fun scrollViewContentWidthUnits(totalWidthUnits: Float, position: LightScrollBarPosition): Float =
+    totalWidthUnits - scrollBarGutterUnits(position)
+
 @Composable
 fun LightScrollView(
     modifier: Modifier = Modifier,
@@ -90,56 +98,33 @@ fun LightScrollView(
     val scope = rememberCoroutineScope()
     val scrollOffsetPx by remember { derivedStateOf { scrollState.value.toFloat() } }
     val showScrollBar = scrollState.maxValue > 0
-    val contentPaddingEnd = when {
-        !showScrollBar -> 0f
-        scrollBarPosition == LightScrollBarPosition.Outside -> SCROLLBAR_WIDTH_UNITS
-        else -> 0f
-    }
+    val contentPaddingEnd = scrollBarGutterUnits(scrollBarPosition)
 
-    if (scrollBarPosition == LightScrollBarPosition.Inside) {
-        Box(modifier = modifier) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .verticalScroll(scrollState),
-                content = content,
-            )
-            if (showScrollBar) {
-                LightScrollBar(
-                    contentScrollOffsetPx = scrollOffsetPx,
-                    maxContentScrollOffsetPx = scrollState.maxValue.toFloat(),
-                    onScrollTo = { target ->
-                        scope.launch { scrollState.scrollTo(target.roundToInt()) }
-                    },
-                    modifier = Modifier
-                        .align(Alignment.CenterEnd)
-                        .fillMaxHeight()
-                        .padding(
-                            vertical = SCROLLBAR_INSIDE_VERTICAL_PADDING_UNITS.gridUnitsAsDp(),
-                        ),
-                )
+    Box(modifier = modifier) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(end = contentPaddingEnd.gridUnitsAsDp())
+                .verticalScroll(scrollState),
+            content = content,
+        )
+        if (showScrollBar) {
+            val verticalPadding = if (scrollBarPosition == LightScrollBarPosition.Inside) {
+                SCROLLBAR_INSIDE_VERTICAL_PADDING_UNITS.gridUnitsAsDp()
+            } else {
+                0.dp
             }
-        }
-    } else {
-        Row(modifier = modifier) {
-            Column(
+            LightScrollBar(
+                contentScrollOffsetPx = scrollOffsetPx,
+                maxContentScrollOffsetPx = scrollState.maxValue.toFloat(),
+                onScrollTo = { target ->
+                    scope.launch { scrollState.scrollTo(target.roundToInt()) }
+                },
                 modifier = Modifier
-                    .weight(1f)
+                    .align(Alignment.CenterEnd)
                     .fillMaxHeight()
-                    .padding(end = contentPaddingEnd.gridUnitsAsDp())
-                    .verticalScroll(scrollState),
-                content = content,
+                    .padding(vertical = verticalPadding),
             )
-            if (showScrollBar) {
-                LightScrollBar(
-                    contentScrollOffsetPx = scrollOffsetPx,
-                    maxContentScrollOffsetPx = scrollState.maxValue.toFloat(),
-                    onScrollTo = { target ->
-                        scope.launch { scrollState.scrollTo(target.roundToInt()) }
-                    },
-                    modifier = Modifier.fillMaxHeight(),
-                )
-            }
         }
     }
 }

--- a/sdk/ui/src/test/kotlin/com/thelightphone/sdk/ui/LightScrollViewLayoutTest.kt
+++ b/sdk/ui/src/test/kotlin/com/thelightphone/sdk/ui/LightScrollViewLayoutTest.kt
@@ -1,0 +1,55 @@
+package com.thelightphone.sdk.ui
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class LightScrollViewLayoutTest {
+
+    @Test
+    fun contentWidthIsInvariantToScrollBarVisibility() {
+        val total = 100f
+        val position = LightScrollBarPosition.Outside
+        val widthWhenBarHidden = scrollViewContentWidthUnits(total, position)
+        val widthWhenBarShown = scrollViewContentWidthUnits(total, position)
+        assertEquals(widthWhenBarHidden, widthWhenBarShown)
+    }
+
+    @Test
+    fun outsideReservesAGutter() {
+        assertTrue(scrollBarGutterUnits(LightScrollBarPosition.Outside) > 0f)
+    }
+
+    @Test
+    fun insideReservesNoGutter() {
+        assertEquals(0f, scrollBarGutterUnits(LightScrollBarPosition.Inside))
+    }
+
+    @Test
+    fun outsideContentWidthIsTotalMinusGutter() {
+        val total = 100f
+        val expected = total - scrollBarGutterUnits(LightScrollBarPosition.Outside)
+        assertEquals(expected, scrollViewContentWidthUnits(total, LightScrollBarPosition.Outside))
+    }
+
+    @Test
+    fun aspectRatioContentDoesNotOscillate() {
+        val total = 100f
+        val gutter = scrollBarGutterUnits(LightScrollBarPosition.Outside)
+        val overflowThreshold = total - gutter / 2f
+        fun overflows(width: Float) = width > overflowThreshold
+        fun contentWidth() = scrollViewContentWidthUnits(total, LightScrollBarPosition.Outside)
+
+        var shown = false
+        val states = mutableListOf(shown)
+        repeat(10) {
+            shown = overflows(contentWidth())
+            states.add(shown)
+        }
+        assertEquals(
+            1,
+            states.takeLast(4).toSet().size,
+            "scrollbar visibility must reach a stable fixpoint, not oscillate: $states",
+        )
+    }
+}


### PR DESCRIPTION
LightScrollView reserved the scrollbar gutter only while the bar was visible, and in the Outside position drew the bar as a Row sibling that consumed horizontal layout space only when shown. This made the content column's width depend on scrollbar visibility.

For fillMaxWidth().aspectRatio() content, a width change produces a proportional height change, which can flip whether the content overflows the viewport, which toggles the scrollbar and changes the width again. The result is an infinite show/hide layout loop, causing the screen to flicker. It triggers whenever aspect-ratio content sits near the scroll threshold.

Fix: reserve the gutter unconditionally and draw the scrollbar as a CenterEnd overlay (consuming no layout space) for both positions, so content width is invariant to bar visibility and the loop cannot form.

This would close #50.