### PR TITLE
feat(ui): accept a caller-provided ScrollState in LightScrollView

### DIFF
--- a/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightScrollView.kt
+++ b/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightScrollView.kt
@@ -1,5 +1,6 @@
 package com.thelightphone.sdk.ui
 
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.awaitEachGesture
 import androidx.compose.foundation.gestures.awaitFirstDown
@@ -92,9 +93,9 @@ fun scrollViewContentWidthUnits(totalWidthUnits: Float, position: LightScrollBar
 fun LightScrollView(
     modifier: Modifier = Modifier,
     scrollBarPosition: LightScrollBarPosition = LightScrollBarPosition.Outside,
+    scrollState: ScrollState = rememberScrollState(),
     content: @Composable ColumnScope.() -> Unit,
 ) {
-    val scrollState = rememberScrollState()
     val scope = rememberCoroutineScope()
     val scrollOffsetPx by remember { derivedStateOf { scrollState.value.toFloat() } }
     val showScrollBar = scrollState.maxValue > 0


### PR DESCRIPTION
LightScrollView creates its scroll state internally, so callers can neither observe the scroll position nor scroll programmatically (e.g. to bring newly revealed content into view). Hoist the state into an optional parameter with the previous behavior as the default, mirroring the listState parameter LightLazyScrollView already exposes.

This would close #74 