### PR TITLE
Allow for server app to foreground itself over tools, Emulator improvements

### DIFF
--- a/sdk/emulator/src/main/kotlin/com/thelightphone/sdk/emulator/EmulatorApplication.kt
+++ b/sdk/emulator/src/main/kotlin/com/thelightphone/sdk/emulator/EmulatorApplication.kt
@@ -1,15 +1,13 @@
 package com.thelightphone.sdk.emulator
 
 import android.app.Application
-import android.content.BroadcastReceiver
 import android.content.Context
-import android.content.Intent
-import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.content.pm.Signature
 import android.util.Log
 import com.thelightphone.sdk.emulator.http.EmulatorHttpServer
 import com.thelightphone.sdk.server.ClientCertType
+import com.thelightphone.sdk.server.DefaultLightSdkServerSettings
 import com.thelightphone.sdk.server.LightSdkServer
 import com.thelightphone.sdk.shared.LightResult
 import java.security.MessageDigest
@@ -21,41 +19,31 @@ private const val LIGHTSDK_DEV_CERT_SHA256 =
 class EmulatorApplication : Application() {
     override fun onCreate() {
         super.onCreate()
-        val filter = IntentFilter(Intent.ACTION_SCREEN_OFF)
-        registerReceiver(lockReceiver, filter)
-        val mollysocketUriString = BuildConfig.MOLLYSOCKET_URI
-        LightSdkServer.customServiceMethodResolver = { callingId, methodId, payload ->
-            if (methodId == "GetMollySocketUri" && mollysocketUriString.isNotEmpty()) {
-                val json = "{\"mollySocketUri\":\"$mollysocketUriString\"}"
-                LightResult.Success(json)
-            } else {
-                LightResult.Error(LightResult.ErrorCode.Unknown)
+        val mollySocketUriString = BuildConfig.MOLLYSOCKET_URI
+        val settings = DefaultLightSdkServerSettings(this)
+        with(LightSdkServer) {
+            registerLockReceiver(MainActivity::class.java, settings)
+            customServiceMethodResolver = { callingId, methodId, payload ->
+                if (methodId == "GetMollySocketUri" && mollySocketUriString.isNotEmpty()) {
+                    val json = "{\"mollySocketUri\":\"$mollySocketUriString\"}"
+                    LightResult.Success(json)
+                } else {
+                    LightResult.Error(LightResult.ErrorCode.Unknown)
+                }
             }
+            val pushDomain = BuildConfig.PUSH_DOMAIN.ifEmpty { "http://localhost:8090" }
+            pushEndpointFetcher = { callingPackage, token, vapid ->
+                Log.d("LightEmulator", "getting push endpoint for token: $token, vapid: $vapid")
+                "$pushDomain/push/$token"
+            }
+            checkCert = { callingPackage ->
+                checkLightSdkCert(callingPackage)
+            }
+            provideSdkSettings = { settings }
+            permissionActivity = LightSdkPermissionActivity::class.java
         }
-        val pushDomain = BuildConfig.PUSH_DOMAIN.ifEmpty { "http://localhost:8090" }
-        LightSdkServer.pushEndpointFetcher = { callingPackage, token, vapid ->
-            Log.d("LightEmulator", "getting push endpoint for token: $token, vapid: $vapid")
-            "$pushDomain/push/$token"
-        }
-
-        LightSdkServer.checkCert = { callingPackage ->
-            checkLightSdkCert(callingPackage)
-        }
-
-        LightSdkServer.permissionActivity = LightSdkPermissionActivity::class.java
 
         EmulatorHttpServer(this).start()
-    }
-
-    private val lockReceiver = object : BroadcastReceiver() {
-        override fun onReceive(context: Context, intent: Intent) {
-            if (intent.action == Intent.ACTION_SCREEN_OFF) {
-                val i = Intent(context, MainActivity::class.java)
-                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-                    .putExtra(SCREEN_OFF_FLAG, true)
-                context.startActivity(i)   // fires while display is off
-            }
-        }
     }
 }
 

--- a/sdk/emulator/src/main/kotlin/com/thelightphone/sdk/emulator/EmulatorApplication.kt
+++ b/sdk/emulator/src/main/kotlin/com/thelightphone/sdk/emulator/EmulatorApplication.kt
@@ -1,7 +1,10 @@
 package com.thelightphone.sdk.emulator
 
 import android.app.Application
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.content.pm.Signature
 import android.util.Log
@@ -18,6 +21,8 @@ private const val LIGHTSDK_DEV_CERT_SHA256 =
 class EmulatorApplication : Application() {
     override fun onCreate() {
         super.onCreate()
+        val filter = IntentFilter(Intent.ACTION_SCREEN_OFF)
+        registerReceiver(lockReceiver, filter)
         val mollysocketUriString = BuildConfig.MOLLYSOCKET_URI
         LightSdkServer.customServiceMethodResolver = { callingId, methodId, payload ->
             if (methodId == "GetMollySocketUri" && mollysocketUriString.isNotEmpty()) {
@@ -40,6 +45,17 @@ class EmulatorApplication : Application() {
         LightSdkServer.permissionActivity = LightSdkPermissionActivity::class.java
 
         EmulatorHttpServer(this).start()
+    }
+
+    private val lockReceiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context, intent: Intent) {
+            if (intent.action == Intent.ACTION_SCREEN_OFF) {
+                val i = Intent(context, MainActivity::class.java)
+                    .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    .putExtra(SCREEN_OFF_FLAG, true)
+                context.startActivity(i)   // fires while display is off
+            }
+        }
     }
 }
 

--- a/sdk/emulator/src/main/kotlin/com/thelightphone/sdk/emulator/EmulatorSettings.kt
+++ b/sdk/emulator/src/main/kotlin/com/thelightphone/sdk/emulator/EmulatorSettings.kt
@@ -1,35 +1,21 @@
 package com.thelightphone.sdk.emulator
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Surface
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.thelightphone.sdk.server.ClientFilterLevel
+import com.thelightphone.sdk.server.ForceFocusLevel
 import com.thelightphone.sdk.server.LightSdkServerSettings
 import com.thelightphone.sdk.shared.LightServiceMethod
-import com.thelightphone.sdk.ui.LightBarButton
-import com.thelightphone.sdk.ui.LightBarButton.*
-import com.thelightphone.sdk.ui.LightIcons
-import com.thelightphone.sdk.ui.LightText
-import com.thelightphone.sdk.ui.LightTextVariant
-import com.thelightphone.sdk.ui.LightTopBar
-import com.thelightphone.sdk.ui.LightTopBarCenter
-import com.thelightphone.sdk.ui.LightTopBarCenter.*
-import com.thelightphone.sdk.ui.gridUnitsAsDp
+import com.thelightphone.sdk.ui.*
+import com.thelightphone.sdk.ui.LightBarButton.LightIcon
 
 private enum class EmulatorSettingsNav {
-    Root, FilterLevel, Keyboard
+    Root, FilterLevel, Keyboard, ForceFocus
 }
 
 val ClientFilterLevel.label: String
@@ -38,6 +24,13 @@ val ClientFilterLevel.label: String
         ClientFilterLevel.AllowLightApprovedApks -> "Community Tools"
         ClientFilterLevel.AllowLightSignedApks -> "Built with SDK"
         ClientFilterLevel.AllowAllApks -> "All Tools"
+    }
+
+val ForceFocusLevel.label: String
+    get() = when (this) {
+        ForceFocusLevel.Always -> "Always Foreground Emulator"
+        ForceFocusLevel.AlertsOnly -> "Foreground Alerts Only"
+        ForceFocusLevel.Never -> "Never Foreground Emulator"
     }
 
 @Composable
@@ -72,6 +65,20 @@ fun EmulatorSettings(settings: LightSdkServerSettings, onBackPressed: () -> Unit
                     Row(
                         Modifier
                             .fillMaxWidth()
+                            .clickable { nav = EmulatorSettingsNav.ForceFocus }
+                            .padding(16.dp)
+                    ) {
+                        Column {
+                            LightText("Force Focus", variant = LightTextVariant.Superfine)
+                            LightText(
+                                settings.forceFocusLevel.label,
+                                variant = LightTextVariant.Subheading
+                            )
+                        }
+                    }
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
                             .clickable { nav = EmulatorSettingsNav.Keyboard }
                             .padding(16.dp)
                     ) {
@@ -86,6 +93,10 @@ fun EmulatorSettings(settings: LightSdkServerSettings, onBackPressed: () -> Unit
             }
 
             EmulatorSettingsNav.FilterLevel -> ClientFilterLevelSettings(settings) {
+                nav = EmulatorSettingsNav.Root
+            }
+
+            EmulatorSettingsNav.ForceFocus -> ForceFocusLevelSettings(settings) {
                 nav = EmulatorSettingsNav.Root
             }
 
@@ -120,6 +131,38 @@ fun ClientFilterLevelSettings(settings: LightSdkServerSettings, onBackPressed: (
                 ) {
                     LightText(
                         clientFilterLevel.label,
+                        variant = LightTextVariant.Subheading
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ForceFocusLevelSettings(settings: LightSdkServerSettings, onBackPressed: () -> Unit) {
+    Surface(Modifier.fillMaxSize()) {
+        Column(Modifier.fillMaxSize()) {
+            LightTopBar(
+                leftButton = LightBarButton.LightIcon(
+                    icon = LightIcons.BACK,
+                    onClick = onBackPressed
+                ),
+                center = LightTopBarCenter.Text("Force Focus Level"),
+                modifier = Modifier.padding(bottom = 1f.gridUnitsAsDp()),
+            )
+            for (forceFocusLevel in ForceFocusLevel.entries) {
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .clickable {
+                            settings.forceFocusLevel = forceFocusLevel
+                            onBackPressed()
+                        }
+                        .padding(16.dp)
+                ) {
+                    LightText(
+                        forceFocusLevel.label,
                         variant = LightTextVariant.Subheading
                     )
                 }
@@ -173,5 +216,21 @@ fun KeyboardSettings(settings: LightSdkServerSettings, onBackPressed: () -> Unit
                 )
             }
         }
+    }
+}
+
+@Preview(widthDp = 1080 / 3, heightDp = 1240 / 3, showBackground = true)
+@Composable
+fun EmulatorSettingsPreview() {
+    val settings = object : LightSdkServerSettings {
+        override var clientFilterLevel: ClientFilterLevel = ClientFilterLevel.AllowAllApks
+        override var keyboardOptions: LightServiceMethod.GetKeyboardOptions.Response =
+            LightServiceMethod.GetKeyboardOptions.Response(null, true, true)
+        override var userPreferences: LightServiceMethod.GetUserPreferences.Response =
+            LightServiceMethod.GetUserPreferences.Response(hapticsEnabled = true)
+        override var forceFocusLevel: ForceFocusLevel = ForceFocusLevel.Always
+    }
+    LightTheme {
+        EmulatorSettings(settings) { }
     }
 }

--- a/sdk/emulator/src/main/kotlin/com/thelightphone/sdk/emulator/LightSdkPermissionActivity.kt
+++ b/sdk/emulator/src/main/kotlin/com/thelightphone/sdk/emulator/LightSdkPermissionActivity.kt
@@ -2,8 +2,6 @@ package com.thelightphone.sdk.emulator
 
 import android.content.pm.PackageManager
 import android.os.Bundle
-import android.os.Process
-import android.os.UserHandle
 import android.util.Log
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
@@ -26,7 +24,6 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.thelightphone.sdk.server.LightSdkServer
-import com.thelightphone.sdk.server.LightSdkServerSettings
 import com.thelightphone.sdk.shared.LightServiceMethod
 import com.thelightphone.sdk.ui.*
 import kotlinx.coroutines.Dispatchers
@@ -72,7 +69,7 @@ class LightSdkPermissionActivity : ComponentActivity() {
             var packageAllowed by remember { mutableStateOf(false) }
             LaunchedEffect(Unit) {
                 withContext(Dispatchers.IO) {
-                    val clientFilterLevel = LightSdkServerSettings(this@LightSdkPermissionActivity).clientFilterLevel
+                    val clientFilterLevel = LightSdkServer.provideSdkSettings(this@LightSdkPermissionActivity).clientFilterLevel
                     packageAllowed = permissionAllowed && LightSdkServer.isPackageAllowed(clientFilterLevel, requester)
                     loading = false
                 }

--- a/sdk/emulator/src/main/kotlin/com/thelightphone/sdk/emulator/MainActivity.kt
+++ b/sdk/emulator/src/main/kotlin/com/thelightphone/sdk/emulator/MainActivity.kt
@@ -1,6 +1,5 @@
 package com.thelightphone.sdk.emulator
 
-import android.app.ComponentCaller
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
@@ -11,25 +10,9 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.*
 import androidx.compose.material3.Surface
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.derivedStateOf
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
@@ -38,23 +21,15 @@ import androidx.compose.ui.unit.dp
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import com.thelightphone.sdk.server.LightSdkServer
 import com.thelightphone.sdk.server.LightSdkServer.queryEnabledClients
 import com.thelightphone.sdk.server.LightSdkServer.runningAsSystemApp
-import com.thelightphone.sdk.server.LightSdkServerSettings
-import com.thelightphone.sdk.ui.LightIcon
-import com.thelightphone.sdk.ui.LightIcons
-import com.thelightphone.sdk.ui.LightText
-import com.thelightphone.sdk.ui.LightTextVariant
-import com.thelightphone.sdk.ui.LightTheme
-import com.thelightphone.sdk.ui.LightThemeColors
-import com.thelightphone.sdk.ui.LightThemeController
-import com.thelightphone.sdk.ui.gridUnitsAsDp
+import com.thelightphone.sdk.ui.*
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
-const val SCREEN_OFF_FLAG = "SCREEN_OFF"
 class MainActivity : ComponentActivity() {
 
     enum class Nav {
@@ -76,7 +51,7 @@ class MainActivity : ComponentActivity() {
                 "WARNING: LightOS emulator is NOT running as a system app and may not work."
             )
         }
-        val serverSettings = LightSdkServerSettings(this)
+        val serverSettings = LightSdkServer.provideSdkSettings(this)
         setContent {
             val themeColors by LightThemeController.colors.collectAsState()
             val currentNav by currentNavFlow.collectAsState()
@@ -90,7 +65,7 @@ class MainActivity : ComponentActivity() {
                     Nav.Toolbox -> {
                         ToolList(
                             fetchExternalTools = {
-                                queryEnabledClients().map {
+                                queryEnabledClients(serverSettings).map {
                                     val appInfo = it.packageInfo.applicationInfo!!
                                     val label =
                                         packageManager.getApplicationLabel(appInfo).toString()
@@ -122,7 +97,7 @@ class MainActivity : ComponentActivity() {
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        val screenTurnedOff = intent.extras?.getBoolean(SCREEN_OFF_FLAG, false) == true
+        val screenTurnedOff = intent.extras?.getBoolean(LightSdkServer.SCREEN_OFF_FLAG, false) == true
         if (screenTurnedOff) {
             currentNavFlow.value = Nav.LockScreen
         }
@@ -214,7 +189,6 @@ private fun LightLockscreen(onUnlockClicked: () -> Unit) {
             ) {
                 var time by remember { mutableStateOf(LocalTime.now()) }
 
-                // Re-runs the loop once; updates state every second
                 LaunchedEffect(Unit) {
                     while (true) {
                         time = LocalTime.now()
@@ -243,8 +217,6 @@ private fun LightLockscreen(onUnlockClicked: () -> Unit) {
 @Composable
 fun LockScreenPreview() {
     LightTheme(colors = LightThemeColors.Dark) {
-        LightLockscreen {
-
-        }
+        LightLockscreen { }
     }
 }

--- a/sdk/emulator/src/main/kotlin/com/thelightphone/sdk/emulator/MainActivity.kt
+++ b/sdk/emulator/src/main/kotlin/com/thelightphone/sdk/emulator/MainActivity.kt
@@ -1,5 +1,7 @@
 package com.thelightphone.sdk.emulator
 
+import android.app.ComponentCaller
+import android.content.Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -10,10 +12,15 @@ import androidx.compose.foundation.gestures.Orientation
 import androidx.compose.foundation.gestures.draggable
 import androidx.compose.foundation.gestures.rememberDraggableState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -24,25 +31,37 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.BiasAlignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.thelightphone.sdk.server.LightSdkServer.queryEnabledClients
 import com.thelightphone.sdk.server.LightSdkServer.runningAsSystemApp
 import com.thelightphone.sdk.server.LightSdkServerSettings
+import com.thelightphone.sdk.ui.LightIcon
+import com.thelightphone.sdk.ui.LightIcons
 import com.thelightphone.sdk.ui.LightText
 import com.thelightphone.sdk.ui.LightTextVariant
 import com.thelightphone.sdk.ui.LightTheme
+import com.thelightphone.sdk.ui.LightThemeColors
 import com.thelightphone.sdk.ui.LightThemeController
+import com.thelightphone.sdk.ui.gridUnitsAsDp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import java.time.LocalTime
+import java.time.format.DateTimeFormatter
 
+const val SCREEN_OFF_FLAG = "SCREEN_OFF"
 class MainActivity : ComponentActivity() {
 
     enum class Nav {
-        Toolbox, Settings
+        LockScreen, Toolbox, Settings
     }
+
+    private val currentNavFlow = MutableStateFlow(Nav.LockScreen)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
@@ -60,38 +79,52 @@ class MainActivity : ComponentActivity() {
         val serverSettings = LightSdkServerSettings(this)
         setContent {
             val themeColors by LightThemeController.colors.collectAsState()
-            var currentNav by remember { mutableStateOf(Nav.Toolbox) }
-            LightTheme(colors = themeColors){
-                when(currentNav) {
+            val currentNav by currentNavFlow.collectAsState()
+            LightTheme(colors = themeColors) {
+                when (currentNav) {
+                    Nav.LockScreen -> {
+                        LightLockscreen {
+                            currentNavFlow.value = Nav.Toolbox
+                        }
+                    }
                     Nav.Toolbox -> {
                         ToolList(
                             fetchExternalTools = {
                                 queryEnabledClients().map {
                                     val appInfo = it.packageInfo.applicationInfo!!
-                                    val label = packageManager.getApplicationLabel(appInfo).toString()
+                                    val label =
+                                        packageManager.getApplicationLabel(appInfo).toString()
                                     ExternalTool(label, it.packageInfo.packageName)
                                 }
                             }, launchPackage = {
                                 packageManager.getLaunchIntentForPackage(it)?.let { intent ->
-                                    intent.addFlags(android.content.Intent.FLAG_ACTIVITY_NO_ANIMATION)
+                                    intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION)
                                     val options =
                                         android.app.ActivityOptions.makeCustomAnimation(this, 0, 0)
                                     startActivity(intent, options.toBundle())
                                 }
                             }, launchDefaultTool = {
-                                when(it) {
-                                    DefaultTool.Settings -> currentNav = Nav.Settings
+                                when (it) {
+                                    DefaultTool.Settings -> currentNavFlow.value = Nav.Settings
                                 }
                             })
                     }
+
                     Nav.Settings -> {
                         EmulatorSettings(serverSettings) {
-                            currentNav = Nav.Toolbox
+                            currentNavFlow.value = Nav.Toolbox
                         }
                     }
                 }
-
             }
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        val screenTurnedOff = intent.extras?.getBoolean(SCREEN_OFF_FLAG, false) == true
+        if (screenTurnedOff) {
+            currentNavFlow.value = Nav.LockScreen
         }
     }
 }
@@ -147,13 +180,71 @@ private fun ToolList(
                     text = tool.label,
                     variant = LightTextVariant.Subtitle,
                     modifier = Modifier.clickable {
-                        when(tool) {
+                        when (tool) {
                             is DefaultTool -> launchDefaultTool(tool)
                             is ExternalTool -> launchPackage(tool.packageName)
                         }
                     }
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun LightLockscreen(onUnlockClicked: () -> Unit) {
+    Surface {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(1f.gridUnitsAsDp())
+        ) {
+            Row(Modifier.fillMaxWidth()) {
+                LightIcon(icon = LightIcons.WIFI, size = 1f)
+                Spacer(Modifier.width(0.5f.gridUnitsAsDp()))
+                LightIcon(icon = LightIcons.BLUETOOTH, size = 1f)
+                Spacer(Modifier.weight(1f))
+                LightIcon(icon = LightIcons.BATTERY_CHARGING, size = 1f)
+            }
+            Box(
+                Modifier
+                    .weight(1f)
+                    .fillMaxWidth()
+            ) {
+                var time by remember { mutableStateOf(LocalTime.now()) }
+
+                // Re-runs the loop once; updates state every second
+                LaunchedEffect(Unit) {
+                    while (true) {
+                        time = LocalTime.now()
+                        delay(1000)
+                    }
+                }
+
+                val formatter = remember { DateTimeFormatter.ofPattern("h:mm") }
+                LightText(
+                    time.format(formatter),
+                    variant = LightTextVariant.Title,
+                    modifier = Modifier.align(BiasAlignment(0f, -0.1f))
+                )
+            }
+            Box(Modifier.clickable(onClick = onUnlockClicked)) {
+                LightIcon(
+                    icon = LightIcons.CIRCLE,
+                    size = 2f
+                )
+            }
+        }
+    }
+}
+
+@Preview(widthDp = 1080 / 3, heightDp = 1240 / 3, showBackground = true)
+@Composable
+fun LockScreenPreview() {
+    LightTheme(colors = LightThemeColors.Dark) {
+        LightLockscreen {
+
         }
     }
 }

--- a/sdk/server/src/main/kotlin/com/thelightphone/sdk/server/LightSdkServer.kt
+++ b/sdk/server/src/main/kotlin/com/thelightphone/sdk/server/LightSdkServer.kt
@@ -2,8 +2,10 @@ package com.thelightphone.sdk.server
 
 import android.Manifest
 import android.app.Activity
+import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
@@ -31,6 +33,7 @@ enum class ClientCertType {
 
 object LightSdkServer {
     private const val TAG = "LightSdkServer"
+    const val SCREEN_OFF_FLAG = "SCREEN_OFF"
 
     val Context.runningAsSystemApp: Boolean
         get() {
@@ -46,8 +49,8 @@ object LightSdkServer {
         return true
     }
 
-    fun List<InstalledClient>.filterAllowedTools(context: Context): List<InstalledClient> {
-        val clientFilterLevel = LightSdkServerSettings(context).clientFilterLevel
+    fun List<InstalledClient>.filterAllowedTools(settings: LightSdkServerSettings): List<InstalledClient> {
+        val clientFilterLevel = settings.clientFilterLevel
         return filter { isPackageAllowed(clientFilterLevel, it.packageInfo.packageName) }
     }
 
@@ -100,13 +103,24 @@ object LightSdkServer {
         }.filterNotNull()
     }
 
-    fun Context.queryEnabledClients(): List<InstalledClient> {
+    fun Context.queryEnabledClients(settings: LightSdkServerSettings): List<InstalledClient> {
         return queryInstalledClients()
             .filter { isSdkVersionSupported(it.sdkVersion) }
-            .filterAllowedTools(this)
+            .filterAllowedTools(settings)
+    }
+
+    var provideSdkSettings: (Context) -> LightSdkServerSettings = {
+        DefaultLightSdkServerSettings(it)
     }
 
     var defaultClientFilterLevel: ClientFilterLevel = ClientFilterLevel.AllowLightApprovedApks
+
+    /**
+     * defines the behavior for when the server app should "foreground" itself over other running apps
+     * LightOS is aggressive about this by default. It will foreground itself for all alerts, and whenever
+     * the phone is locked.
+     */
+    var defaultForceFocusLevel: ForceFocusLevel = ForceFocusLevel.Always
 
     /**
      * return the POST endpoint that the calling tool's application server should use to
@@ -171,5 +185,30 @@ object LightSdkServer {
                 Process.myUserHandle()
             )
         }
+    }
+
+    /**
+     * A receiver that will bring the rootActivity (MainActivity in both emulator and real LightOS)
+     * to the foreground with a new intent whenever the device's screen goes off
+     * (unless user has overridden the settings.forceFocusLevel)
+     */
+    fun Context.registerLockReceiver(rootActivityClass: Class<out Activity>, settings: LightSdkServerSettings) : BroadcastReceiver {
+        val filter = IntentFilter(Intent.ACTION_SCREEN_OFF)
+        val lockReceiver = object : BroadcastReceiver() {
+            override fun onReceive(context: Context, intent: Intent) {
+                val allowForceFocus = when(settings.forceFocusLevel) {
+                    ForceFocusLevel.Always -> true
+                    ForceFocusLevel.AlertsOnly, ForceFocusLevel.Never -> false
+                }
+                if (allowForceFocus && intent.action == Intent.ACTION_SCREEN_OFF) {
+                    val i = Intent(context, rootActivityClass)
+                        .addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        .putExtra(SCREEN_OFF_FLAG, true)
+                    context.startActivity(i)
+                }
+            }
+        }
+        registerReceiver(lockReceiver, filter)
+        return lockReceiver
     }
 }

--- a/sdk/server/src/main/kotlin/com/thelightphone/sdk/server/LightSdkServerSettings.kt
+++ b/sdk/server/src/main/kotlin/com/thelightphone/sdk/server/LightSdkServerSettings.kt
@@ -21,11 +21,38 @@ enum class ClientFilterLevel {
     AllowAllApks
 }
 
-class LightSdkServerSettings(context: Context) {
+enum class ForceFocusLevel {
+    // The server app will pull itself into the foreground when any alerts fire, AND when
+    // the device locks (so that it can act as the home/lock screen - default behavior in LightOS)
+    Always,
+
+    // Server app will pull itself into the foreground when any alerts fire
+    AlertsOnly,
+
+    // Server app will never pull itself into the foreground
+    Never
+}
+
+interface LightSdkServerSettings {
+    var clientFilterLevel: ClientFilterLevel
+    var keyboardOptions: LightServiceMethod.GetKeyboardOptions.Response
+    var userPreferences: LightServiceMethod.GetUserPreferences.Response
+
+    /**
+     * defines the behavior for when the server app should "foreground" itself over other running apps
+     * LightOS is aggressive about this by default. It will foreground itself for all alerts, and whenever
+     * the phone is locked.
+     */
+    var forceFocusLevel: ForceFocusLevel
+}
+
+class DefaultLightSdkServerSettings(context: Context) : LightSdkServerSettings {
 
     companion object {
         const val TAG = "LightSdkServerSettings"
         private const val CLIENT_FILTER_LEVEL = "client_filter_level"
+        private const val FORCE_FOCUS_LEVEL = "force_focus_level"
+        private const val USER_PREFERENCES_HAPTICS = "user_preferences_haptics_enabled"
         private const val KEYBOARD_EMOJIS = "lp3_keyboard_emojis"
         private const val KEYBOARD_SHOW_VOICE = "lp3_keyboard_show_voice"
         private const val KEYBOARD_ENABLE_KEY_ANIMATION = "lp3_keyboard_enable_key_animation"
@@ -35,7 +62,7 @@ class LightSdkServerSettings(context: Context) {
     private val preferences: SharedPreferences =
         context.getSharedPreferences("light_sdk_server", MODE_PRIVATE)
 
-    var clientFilterLevel: ClientFilterLevel
+    override var clientFilterLevel: ClientFilterLevel
         get() = preferences
             .getInt(CLIENT_FILTER_LEVEL, LightSdkServer.defaultClientFilterLevel.ordinal)
             .let { index ->
@@ -48,8 +75,30 @@ class LightSdkServerSettings(context: Context) {
             preferences.edit().putInt(CLIENT_FILTER_LEVEL, value.ordinal).apply()
         }
 
+    override var forceFocusLevel: ForceFocusLevel
+        get() = preferences
+            .getInt(FORCE_FOCUS_LEVEL, LightSdkServer.defaultForceFocusLevel.ordinal)
+            .let { index ->
+                ForceFocusLevel.entries.getOrElse(index) {
+                    Log.e(TAG, "Invalid value for client filter level: $it")
+                    LightSdkServer.defaultForceFocusLevel
+                }
+            }
+        set(value) {
+            preferences.edit().putInt(FORCE_FOCUS_LEVEL, value.ordinal).apply()
+        }
+
+    override var userPreferences: LightServiceMethod.GetUserPreferences.Response
+        get() {
+            val hapticsEnabled = preferences.getBoolean(USER_PREFERENCES_HAPTICS, false)
+            return LightServiceMethod.GetUserPreferences.Response(hapticsEnabled)
+        }
+        set(value) {
+            preferences.edit().putBoolean(USER_PREFERENCES_HAPTICS, value.hapticsEnabled).apply()
+        }
+
     // store in system settings for now so readable from apps that can't talk to server
-    var keyboardOptions: LightServiceMethod.GetKeyboardOptions.Response
+    override var keyboardOptions: LightServiceMethod.GetKeyboardOptions.Response
         get() {
             return LightServiceMethod.GetKeyboardOptions.Response(
                 emojisAsString = Settings.System.getString(contentResolver, KEYBOARD_EMOJIS),

--- a/sdk/server/src/main/kotlin/com/thelightphone/sdk/server/LightSdkServerSettings.kt
+++ b/sdk/server/src/main/kotlin/com/thelightphone/sdk/server/LightSdkServerSettings.kt
@@ -51,7 +51,7 @@ class DefaultLightSdkServerSettings(context: Context) : LightSdkServerSettings {
     companion object {
         const val TAG = "LightSdkServerSettings"
         private const val CLIENT_FILTER_LEVEL = "client_filter_level"
-        private const val FORCE_FOCUS_LEVEL = "force_focus_level"
+        private const val FORCE_FOCUS_LEVEL = "light_force_focus_level"
         private const val USER_PREFERENCES_HAPTICS = "user_preferences_haptics_enabled"
         private const val KEYBOARD_EMOJIS = "lp3_keyboard_emojis"
         private const val KEYBOARD_SHOW_VOICE = "lp3_keyboard_show_voice"
@@ -75,17 +75,20 @@ class DefaultLightSdkServerSettings(context: Context) : LightSdkServerSettings {
             preferences.edit().putInt(CLIENT_FILTER_LEVEL, value.ordinal).apply()
         }
 
+    // store in system settings, likely only going to expose for users using adb
     override var forceFocusLevel: ForceFocusLevel
-        get() = preferences
-            .getInt(FORCE_FOCUS_LEVEL, LightSdkServer.defaultForceFocusLevel.ordinal)
-            .let { index ->
-                ForceFocusLevel.entries.getOrElse(index) {
-                    Log.e(TAG, "Invalid value for client filter level: $it")
-                    LightSdkServer.defaultForceFocusLevel
-                }
+        get() = Settings.System.getInt(
+            contentResolver,
+            FORCE_FOCUS_LEVEL,
+            LightSdkServer.defaultForceFocusLevel.ordinal
+        ).let { index ->
+            ForceFocusLevel.entries.getOrElse(index) {
+                Log.e(TAG, "Invalid value for client filter level: $it")
+                LightSdkServer.defaultForceFocusLevel
             }
+        }
         set(value) {
-            preferences.edit().putInt(FORCE_FOCUS_LEVEL, value.ordinal).apply()
+            Settings.System.putInt(contentResolver, FORCE_FOCUS_LEVEL, value.ordinal)
         }
 
     override var userPreferences: LightServiceMethod.GetUserPreferences.Response

--- a/sdk/server/src/main/kotlin/com/thelightphone/sdk/server/LightSdkService.kt
+++ b/sdk/server/src/main/kotlin/com/thelightphone/sdk/server/LightSdkService.kt
@@ -25,7 +25,7 @@ class LightSdkService : Service() {
 
     // TODO something more robust
     private val tokensByUid = mutableMapOf<Int, String>()
-    private val settings by lazy { LightSdkServerSettings(this) }
+    private val settings by lazy { LightSdkServer.provideSdkSettings(this) }
 
     private fun verifyCallerIsInstalledClient(callingId: Int): Boolean {
         val packages = packageManager.getPackagesForUid(callingId) ?: return false
@@ -216,6 +216,13 @@ class LightSdkService : Service() {
                         )
                     )
                 }
+            }
+
+            LightServiceMethod.GetUserPreferences -> {
+                val preferencesSnapshot = settings.userPreferences
+                LightResult.Success(
+                    LightServiceMethod.GetUserPreferences.encodeResponse(preferencesSnapshot)
+                )
             }
 
             null -> {

--- a/sdk/shared/src/main/kotlin/com/thelightphone/sdk/shared/LightServiceMethod.kt
+++ b/sdk/shared/src/main/kotlin/com/thelightphone/sdk/shared/LightServiceMethod.kt
@@ -73,6 +73,17 @@ sealed interface LightServiceMethod<TRequest, TResponse> {
         )
     }
 
+    object GetUserPreferences : LightServiceMethod<Unit, GetUserPreferences.Response> {
+        override val id = "GetUserPreferences"
+        override val requestSerializer = serializer<Unit>()
+        override val responseSerializer = serializer<Response>()
+
+        @Serializable
+        data class Response(
+            val hapticsEnabled: Boolean,
+        )
+    }
+
     object GetPermission : LightServiceMethod<GetPermission.Request, GetPermission.Response> {
         enum class Result {
             Unknown, BlockedByServer, Granted, Denied


### PR DESCRIPTION
In LightOS, alerts (alarms, incoming calls, calendar alerts, timers, etc) takeover whatever tool is currently being viewed. Since LightOS was traditionally a single app/single activity, we never really had to re-order anything. Everything was displayed within `MainActivity`, and `MainActivity` was effectively always foregrounded. Now, if a user's in a community tool (separate APK), and a LightOS alert pops up, it needs to yeet itself in front of the active tool. And more importantly, since LightOS acts as the lock/homescreen on LP3's, it _also_ needs to pull itself forward when the phone is locked. This PR provides a BroadcastReceiver for the server app to listen for SCREEN_OFF events and provide an Activity to be launched/focused when this happens. We've also added a setting to suppress this behavior since it may be annoying to folks who have already modded their phones. 

The emulator has also been updated with a home screen that mostly matches LightOS'. The Android home button behavior is slightly different since we cannot intercept the Home key presses on the emulator image like we can on real LP3's (you can't toggle between home screen/toolbox on the emulator currently).

I'm also sneaking in a `GetUserPreferences` api where clients can query generic settings from the server app. Right now the only field is `hapticsEnabled`. Feel free to make requests for more LightOS settings that you might like exposed there. Another obvious one is light/dark mode but I have a hunch there aren't too many of you actually using light mode?