### PR TITLE
fix: return list of location search results in weather tool

### DIFF
--- a/examples/authenticator/lighttool.toml
+++ b/examples/authenticator/lighttool.toml
@@ -1,8 +1,8 @@
 [tool]
 id = "com.thelightphone.authenticator"
 label = "Authenticator"
-versionCode = 1
-versionName = "1.0"
+versionCode = 2
+versionName = "2.0"
 permissions = ["android.permission.CAMERA"]
 # change if you run this on the emulator!
 # serverPackage = "com.thelightphone.sdk.emulator"

--- a/examples/weather/lighttool.toml
+++ b/examples/weather/lighttool.toml
@@ -1,8 +1,8 @@
 [tool]
 id = "com.thelightphone.weather"
 label = "Weather"
-versionCode = 1
-versionName = "1.0"
+versionCode = 3
+versionName = "3.0"
 permissions = ["android.permission.INTERNET"]
 # change if you run this on the emulator!
 # serverPackage = "com.thelightphone.sdk.emulator"

--- a/examples/weather/src/main/kotlin/com/thelightphone/weather/WeatherApi.kt
+++ b/examples/weather/src/main/kotlin/com/thelightphone/weather/WeatherApi.kt
@@ -14,6 +14,8 @@ import kotlinx.serialization.json.Json
 import java.net.URLEncoder
 import kotlin.text.Charsets.UTF_8
 
+private const val WEATHER_API_BASE = "https://production.lightphonecloud.com"
+
 @Serializable
 internal data class GeocodingResponse(
     val results: List<GeocodingResult> = emptyList(),
@@ -80,7 +82,7 @@ internal class WeatherApi {
     suspend fun searchLocations(query: String): Result<List<GeocodingResult>> = runCatching {
         val encoded = URLEncoder.encode(query.trim(), UTF_8.name())
         val response = client.get(
-            "https://geocoding-api.open-meteo.com/v1/search?name=$encoded&count=15",
+            "$WEATHER_API_BASE/tools/weather/geolocation?name=$encoded&count=15",
         )
 
         if (!response.status.isSuccess()) {
@@ -94,7 +96,7 @@ internal class WeatherApi {
 
     suspend fun fetchForecast(latitude: Double, longitude: Double): Result<StoredForecast> = runCatching {
         val response = client.get(
-            "https://api.open-meteo.com/v1/forecast" +
+            "$WEATHER_API_BASE/tools/weather/forecast" +
                 "?latitude=$latitude&longitude=$longitude" +
                 "&current=temperature_2m,apparent_temperature,weather_code" +
                 "&hourly=temperature_2m,apparent_temperature,precipitation,precipitation_probability" +

--- a/examples/weather/src/main/kotlin/com/thelightphone/weather/WeatherApi.kt
+++ b/examples/weather/src/main/kotlin/com/thelightphone/weather/WeatherApi.kt
@@ -20,7 +20,7 @@ internal data class GeocodingResponse(
 )
 
 @Serializable
-internal data class GeocodingResult(
+data class GeocodingResult(
     val name: String,
     val latitude: Double,
     val longitude: Double,
@@ -77,10 +77,10 @@ internal class WeatherApi {
         }
     }
 
-    suspend fun resolveLocation(query: String): Result<GeocodingResult> = runCatching {
+    suspend fun searchLocations(query: String): Result<List<GeocodingResult>> = runCatching {
         val encoded = URLEncoder.encode(query.trim(), UTF_8.name())
         val response = client.get(
-            "https://geocoding-api.open-meteo.com/v1/search?name=$encoded&count=1",
+            "https://geocoding-api.open-meteo.com/v1/search?name=$encoded&count=15",
         )
 
         if (!response.status.isSuccess()) {
@@ -89,7 +89,7 @@ internal class WeatherApi {
         }
 
         val geo: GeocodingResponse = response.body()
-        geo.results.firstOrNull() ?: throw LocationNotFoundException()
+        geo.results.ifEmpty { throw LocationNotFoundException() }
     }
 
     suspend fun fetchForecast(latitude: Double, longitude: Double): Result<StoredForecast> = runCatching {
@@ -187,7 +187,10 @@ private fun OpenMeteoHourly.toHourlyForecasts(): List<HourlyForecast> {
     }
 }
 
-internal fun GeocodingResult.displayName(): String {
-    val region = listOfNotNull(admin1, country).joinToString(", ")
+fun GeocodingResult.displayName(): String {
+    val region = regionLabel()
     return if (region.isEmpty()) name else "$name, $region"
 }
+
+fun GeocodingResult.regionLabel(): String =
+    listOfNotNull(admin1, country).joinToString(", ")

--- a/examples/weather/src/main/kotlin/com/thelightphone/weather/WeatherHomeScreen.kt
+++ b/examples/weather/src/main/kotlin/com/thelightphone/weather/WeatherHomeScreen.kt
@@ -97,6 +97,14 @@ class WeatherHomeScreen(sealedActivity: SealedLightActivity) :
                         )
                     }
 
+                    is WeatherScreenMode.LocationSearchResults -> {
+                        LocationSearchResultsContent(
+                            results = mode.results,
+                            onSelect = viewModel::selectLocationResult,
+                            onBack = viewModel::cancelLocationSearchResults,
+                        )
+                    }
+
                     is WeatherScreenMode.Loading -> {
                         Column(modifier = Modifier.fillMaxSize()) {
                             LightTopBar(
@@ -176,6 +184,53 @@ class WeatherHomeScreen(sealedActivity: SealedLightActivity) :
                         message = message,
                         onClose = viewModel::dismissError,
                     )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun LocationSearchResultsContent(
+    results: List<GeocodingResult>,
+    onSelect: (GeocodingResult) -> Unit,
+    onBack: () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxSize()) {
+        LightTopBar(
+            leftButton = LightBarButton.LightIcon(
+                icon = LightIcons.BACK,
+                onClick = onBack,
+                contentDescription = "Back",
+            ),
+            center = LightTopBarCenter.Text("Search Results"),
+            modifier = Modifier.padding(bottom = 0.25f.gridUnitsAsDp()),
+        )
+
+        LightScrollView(
+            modifier = Modifier
+                .weight(1f)
+                .fillMaxWidth()
+                .padding(start = 1f.gridUnitsAsDp()),
+        ) {
+            results.forEach { result ->
+                val region = result.regionLabel()
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .lightClickable(onClick = { onSelect(result) })
+                        .padding(bottom = 1f.gridUnitsAsDp()),
+                ) {
+                    LightText(
+                        text = result.name,
+                        variant = LightTextVariant.Copy,
+                    )
+                    if (region.isNotEmpty()) {
+                        LightText(
+                            text = region,
+                            variant = LightTextVariant.Detail,
+                        )
+                    }
                 }
             }
         }

--- a/examples/weather/src/main/kotlin/com/thelightphone/weather/WeatherViewModel.kt
+++ b/examples/weather/src/main/kotlin/com/thelightphone/weather/WeatherViewModel.kt
@@ -20,6 +20,10 @@ import kotlinx.serialization.json.Json
 
 sealed class WeatherScreenMode {
     data object LocationInput : WeatherScreenMode()
+    data class LocationSearchResults(
+        val query: String,
+        val results: List<GeocodingResult>,
+    ) : WeatherScreenMode()
     data object Loading : WeatherScreenMode()
     data class Settings(val locationName: String) : WeatherScreenMode()
     data object Attribution : WeatherScreenMode()
@@ -165,7 +169,8 @@ class WeatherViewModel(
             }
             is WeatherScreenMode.Weekly,
             is WeatherScreenMode.Settings,
-            is WeatherScreenMode.Attribution -> restoreWeatherScreen(selectedDayIndex = 0)
+            is WeatherScreenMode.Attribution,
+            is WeatherScreenMode.LocationSearchResults -> restoreWeatherScreen(selectedDayIndex = 0)
             else -> Unit
         }
     }
@@ -245,16 +250,17 @@ class WeatherViewModel(
                     )
                 }
 
-                val geoResult = api.resolveLocation(query)
-                geoResult.fold(
-                    onSuccess = { geo ->
-                        refreshForecast(
-                            query = query,
-                            locationName = geo.displayName(),
-                            latitude = geo.latitude,
-                            longitude = geo.longitude,
-                            showLoadingScreen = true,
-                        )
+                val searchResult = api.searchLocations(query)
+                searchResult.fold(
+                    onSuccess = { results ->
+                        updateState {
+                            it.copy(
+                                mode = WeatherScreenMode.LocationSearchResults(
+                                    query = query,
+                                    results = results,
+                                ),
+                            )
+                        }
                     },
                     onFailure = { error ->
                         showApiFailure(error)
@@ -264,6 +270,29 @@ class WeatherViewModel(
                 showApiFailure()
             }
         }
+    }
+
+    fun selectLocationResult(result: GeocodingResult) {
+        val query = (_uiState.value.mode as? WeatherScreenMode.LocationSearchResults)?.query
+            ?: return
+
+        viewModelScope.launch(Dispatchers.IO + apiExceptionHandler) {
+            runCatching {
+                refreshForecast(
+                    query = query,
+                    locationName = result.displayName(),
+                    latitude = result.latitude,
+                    longitude = result.longitude,
+                    showLoadingScreen = true,
+                )
+            }.onFailure {
+                showApiFailure()
+            }
+        }
+    }
+
+    fun cancelLocationSearchResults() {
+        _uiState.update { it.openLocationInput(canCancel = it.canCancelLocationInput) }
     }
 
     private suspend fun refreshForecast(


### PR DESCRIPTION
Since the open meteo geocoding api doesn't accept strings that include administrative region or country (e.g. searching for "Camden, New Jersey" doesn't work), we have to return a list of results to allow for user selection.

<img width="464" height="544" alt="image" src="https://github.com/user-attachments/assets/6d1afc9b-e35a-4294-8faa-cee5bbfb8ce8" />
