### PR TITLE
feat(sdk): add configurable media3 player builder

### DIFF
--- a/docs/design_decisions/detached_audio.md
+++ b/docs/design_decisions/detached_audio.md
@@ -101,7 +101,7 @@ Being in the same process allows the tool code and the service to access the sam
 
 - enforcing one detached handle
 - recording the live session's audio usage
-- carrying construction-time configuration to the service before it builds its player, and recording what the live session was built with
+- staging caches and source factory for `onCreate`, then recording what the live session was built with
 - telling the service whether a tool still holds the detached handle.
 
 The public player API is backed by media3's `Player` interface.
@@ -118,15 +118,7 @@ The SDK maps its audio API onto the media3 components as follows:
 
 The controller identifies itself as a tool controller and sends its `LightAudioUsage` through connection hints. Other platform controllers, such as Bluetooth, may connect to the session, but they do not own the SDK's detached handle or select its audio usage.
 
-### Configuration that connection hints cannot carry
-
-Audio usage travels as a connection hint because it can be applied to a player that already exists. Where a player reads bytes from cannot: a media source factory is a constructor argument, and `onCreate` has already built the player by the time the first controller connects. Connection hints are therefore too late for anything settled at construction.
-
-Such configuration goes through `DetachedSessionState` instead. The tool stages it there before asking for a controller — which is what starts the service — and the service takes it in `onCreate`. This works only because the service shares the tool's process, and it is the reason `LightMediaCache` is described as data the SDK acts on rather than handed over as a configured media3 object: a lambda holding tool state would run inside a service the tool does not own, and a media3 object built by the tool would make its lifetime the tool's problem.
-
-Because construction is the only chance, a live session's caches cannot be adopted the way its usage can. Reconnecting with a different set throws rather than being silently ignored, and a session the system revived rather than a tool started records that it was built without caches, so a later handle asking for them is refused instead of being handed a player that has none.
-
-`LightMediaSourceFactory` travels the same way, with one difference. Caches are data and can be compared, so a reconnect asking for the same ones is allowed through. Two factories are indistinguishable whether or not they would build the same pipeline, so there is no comparison to make: a reconnecting handle must pass no factory at all, and the service keeps only whether the live session had one. The lambda itself is dropped once the player exists, since it can never be applied to a second one.
+Caches and `LightMediaSourceFactory` are construction-time, so they are staged on `DetachedSessionState` before the controller starts the service. Reconnecting must match the live session's caches and must not pass a source factory.
 
 ## Foreground-service notification on LP3
 

--- a/docs/design_decisions/detached_audio.md
+++ b/docs/design_decisions/detached_audio.md
@@ -126,6 +126,8 @@ Such configuration goes through `DetachedSessionState` instead. The tool stages 
 
 Because construction is the only chance, a live session's caches cannot be adopted the way its usage can. Reconnecting with a different set throws rather than being silently ignored, and a session the system revived rather than a tool started records that it was built without caches, so a later handle asking for them is refused instead of being handed a player that has none.
 
+`LightMediaSourceFactory` travels the same way, with one difference. Caches are data and can be compared, so a reconnect asking for the same ones is allowed through. Two factories are indistinguishable whether or not they would build the same pipeline, so there is no comparison to make: a reconnecting handle must pass no factory at all, and the service keeps only whether the live session had one. The lambda itself is dropped once the player exists, since it can never be applied to a second one.
+
 ## Foreground-service notification on LP3
 
 Android requires a media-playback foreground service to publish a notification.

--- a/docs/design_decisions/detached_audio.md
+++ b/docs/design_decisions/detached_audio.md
@@ -101,6 +101,7 @@ Being in the same process allows the tool code and the service to access the sam
 
 - enforcing one detached handle
 - recording the live session's audio usage
+- carrying construction-time configuration to the service before it builds its player, and recording what the live session was built with
 - telling the service whether a tool still holds the detached handle.
 
 The public player API is backed by media3's `Player` interface.
@@ -116,6 +117,14 @@ The SDK maps its audio API onto the media3 components as follows:
 - Releasing `LightAudioPlayer` closes its controller and handle without releasing the service-owned player.
 
 The controller identifies itself as a tool controller and sends its `LightAudioUsage` through connection hints. Other platform controllers, such as Bluetooth, may connect to the session, but they do not own the SDK's detached handle or select its audio usage.
+
+### Configuration that connection hints cannot carry
+
+Audio usage travels as a connection hint because it can be applied to a player that already exists. Where a player reads bytes from cannot: a media source factory is a constructor argument, and `onCreate` has already built the player by the time the first controller connects. Connection hints are therefore too late for anything settled at construction.
+
+Such configuration goes through `DetachedSessionState` instead. The tool stages it there before asking for a controller — which is what starts the service — and the service takes it in `onCreate`. This works only because the service shares the tool's process, and it is the reason `LightMediaCache` is described as data the SDK acts on rather than handed over as a configured media3 object: a lambda holding tool state would run inside a service the tool does not own, and a media3 object built by the tool would make its lifetime the tool's problem.
+
+Because construction is the only chance, a live session's caches cannot be adopted the way its usage can. Reconnecting with a different set throws rather than being silently ignored, and a session the system revived rather than a tool started records that it was built without caches, so a later handle asking for them is refused instead of being handed a player that has none.
 
 ## Foreground-service notification on LP3
 

--- a/docs/tool_metadata/README.md
+++ b/docs/tool_metadata/README.md
@@ -51,6 +51,15 @@ capabilities = ["detached-audio"]
 
 `detached-audio` generates the `FOREGROUND_SERVICE` and `FOREGROUND_SERVICE_MEDIA_PLAYBACK` permissions, the detached audio service, and the SDK marker checked by `LightAudio.newPlayer`. None of those permissions can be listed under `permissions`. The capability owns them, and the build fails with an error naming the capability to declare instead.
 
+DASH playback uses:
+
+```toml
+[tool]
+capabilities = ["audio-dash"]
+```
+
+`audio-dash` adds the media3 DASH source to your tool's dependencies, at the media3 version the SDK is built against. It is a capability rather than a dependency you declare because every tool would otherwise carry a format almost none of them play.
+
 ### `orientation` — optional screen orientation lock
 Set to `"portrait"` to keep the tool in portrait orientation. Omit this field to
 let the system choose the orientation.

--- a/examples/audio-demo/src/test/kotlin/com/thelightphone/audiodemo/ToneScreenTest.kt
+++ b/examples/audio-demo/src/test/kotlin/com/thelightphone/audiodemo/ToneScreenTest.kt
@@ -9,7 +9,10 @@ import com.thelightphone.sdk.audio.LightAudioPlayback
 import com.thelightphone.sdk.audio.LightAudioRecorder
 import com.thelightphone.sdk.audio.LightAudioUsage
 import com.thelightphone.sdk.audio.LightAudioVoice
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
 import com.thelightphone.sdk.audio.LightMediaCache
+import com.thelightphone.sdk.audio.LightMediaSourceFactory
 import com.thelightphone.sdk.audio.RecorderConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -28,10 +31,12 @@ class ToneScreenTest {
         val vm = ToneViewModel(object : LightAudio {
             override val capabilities: AudioCapabilities = AudioCapabilities(67)
 
+            @OptIn(UnstableApi::class)
             override fun newPlayer(
                 usage: LightAudioUsage,
                 playback: LightAudioPlayback,
                 caches: List<LightMediaCache>,
+                sourceFactory: LightMediaSourceFactory?,
             ): LightAudioPlayer {
                 TODO("Should not be called")
             }

--- a/examples/audio-demo/src/test/kotlin/com/thelightphone/audiodemo/ToneScreenTest.kt
+++ b/examples/audio-demo/src/test/kotlin/com/thelightphone/audiodemo/ToneScreenTest.kt
@@ -9,6 +9,7 @@ import com.thelightphone.sdk.audio.LightAudioPlayback
 import com.thelightphone.sdk.audio.LightAudioRecorder
 import com.thelightphone.sdk.audio.LightAudioUsage
 import com.thelightphone.sdk.audio.LightAudioVoice
+import com.thelightphone.sdk.audio.LightMediaCache
 import com.thelightphone.sdk.audio.RecorderConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -30,6 +31,7 @@ class ToneScreenTest {
             override fun newPlayer(
                 usage: LightAudioUsage,
                 playback: LightAudioPlayback,
+                caches: List<LightMediaCache>,
             ): LightAudioPlayer {
                 TODO("Should not be called")
             }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,8 @@ androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref =
 androidx-work-runtime = { module = "androidx.work:work-runtime-ktx", version.ref = "work" }
 androidx-media3-common = { module = "androidx.media3:media3-common", version.ref = "media3" }
 androidx-media3-exoplayer = { module = "androidx.media3:media3-exoplayer", version.ref = "media3" }
+androidx-media3-datasource = { module = "androidx.media3:media3-datasource", version.ref = "media3" }
+androidx-media3-database = { module = "androidx.media3:media3-database", version.ref = "media3" }
 androidx-media3-session = { module = "androidx.media3:media3-session", version.ref = "media3" }
 
 [plugins]

--- a/plugin/build.gradle.kts
+++ b/plugin/build.gradle.kts
@@ -34,6 +34,12 @@ kotlin {
 
 tasks.test {
     useJUnitPlatform()
+    // Lets a test check the media3 version the plugin hardcodes against the
+    // catalog the SDK builds with, which is outside this included build.
+    systemProperty(
+        "light.versionCatalog",
+        rootDir.resolve("../gradle/libs.versions.toml").absolutePath,
+    )
 }
 
 gradlePlugin {

--- a/plugin/src/main/kotlin/com/thelightphone/plugin/LightSdkPlugin.kt
+++ b/plugin/src/main/kotlin/com/thelightphone/plugin/LightSdkPlugin.kt
@@ -260,9 +260,6 @@ class LightSdkPlugin : Plugin<Project> {
             throw GradleException("Light SDK: ${e.message}")
         }
 
-        // A capability may need code the SDK does not ship to every tool. Added
-        // here rather than written by the tool, for the same reason its
-        // permissions are: the capability is the single source of truth.
         metadata.capabilities
             .flatMap { LightToolPolicy.CAPABILITY_IMPLIED_DEPENDENCIES[it].orEmpty() }
             .forEach { project.dependencies.add("implementation", it) }

--- a/plugin/src/main/kotlin/com/thelightphone/plugin/LightSdkPlugin.kt
+++ b/plugin/src/main/kotlin/com/thelightphone/plugin/LightSdkPlugin.kt
@@ -260,6 +260,13 @@ class LightSdkPlugin : Plugin<Project> {
             throw GradleException("Light SDK: ${e.message}")
         }
 
+        // A capability may need code the SDK does not ship to every tool. Added
+        // here rather than written by the tool, for the same reason its
+        // permissions are: the capability is the single source of truth.
+        metadata.capabilities
+            .flatMap { LightToolPolicy.CAPABILITY_IMPLIED_DEPENDENCIES[it].orEmpty() }
+            .forEach { project.dependencies.add("implementation", it) }
+
         // Generated manifest path. Anchored under build/ so a clean rebuild
         // always regenerates from current metadata.
         val generatedManifestDir = File(project.layout.buildDirectory.asFile.get(), "generated/light-sdk")

--- a/plugin/src/main/kotlin/com/thelightphone/plugin/LightToolMetadata.kt
+++ b/plugin/src/main/kotlin/com/thelightphone/plugin/LightToolMetadata.kt
@@ -192,22 +192,10 @@ object LightToolPolicy {
 
     val ALLOWED_CAPABILITIES: Set<String> = setOf(DETACHED_AUDIO, AUDIO_DASH)
 
-    /**
-     * The media3 version the SDK is built against. A capability dependency has
-     * to name one, and it has to be this one, or the tool would resolve a media3
-     * split across two versions. `Media3VersionTest` fails if it drifts from the
-     * version catalog.
-     */
+    /** media3 version the SDK is built against. Keep in sync with the catalog. */
     const val MEDIA3_VERSION: String = "1.10.1"
 
-    /**
-     * Dependencies a capability puts on the tool's classpath.
-     *
-     * Format support is a dependency rather than a switch: media3 finds a
-     * DASH source by looking for one, so shipping it to every tool would cost
-     * every tool size for a format almost none of them play. The capability is
-     * how a tool says it is one of the few.
-     */
+    /** Dependencies a capability puts on the tool's classpath. */
     val CAPABILITY_IMPLIED_DEPENDENCIES: Map<String, List<String>> = mapOf(
         AUDIO_DASH to listOf("androidx.media3:media3-exoplayer-dash:$MEDIA3_VERSION"),
     )

--- a/plugin/src/main/kotlin/com/thelightphone/plugin/LightToolMetadata.kt
+++ b/plugin/src/main/kotlin/com/thelightphone/plugin/LightToolMetadata.kt
@@ -188,8 +188,29 @@ object LightToolPolicy {
     )
 
     const val DETACHED_AUDIO: String = "detached-audio"
+    const val AUDIO_DASH: String = "audio-dash"
 
-    val ALLOWED_CAPABILITIES: Set<String> = setOf(DETACHED_AUDIO)
+    val ALLOWED_CAPABILITIES: Set<String> = setOf(DETACHED_AUDIO, AUDIO_DASH)
+
+    /**
+     * The media3 version the SDK is built against. A capability dependency has
+     * to name one, and it has to be this one, or the tool would resolve a media3
+     * split across two versions. `Media3VersionTest` fails if it drifts from the
+     * version catalog.
+     */
+    const val MEDIA3_VERSION: String = "1.10.1"
+
+    /**
+     * Dependencies a capability puts on the tool's classpath.
+     *
+     * Format support is a dependency rather than a switch: media3 finds a
+     * DASH source by looking for one, so shipping it to every tool would cost
+     * every tool size for a format almost none of them play. The capability is
+     * how a tool says it is one of the few.
+     */
+    val CAPABILITY_IMPLIED_DEPENDENCIES: Map<String, List<String>> = mapOf(
+        AUDIO_DASH to listOf("androidx.media3:media3-exoplayer-dash:$MEDIA3_VERSION"),
+    )
 
     /**
      * Permissions a capability contributes to the generated manifest. These are

--- a/plugin/src/test/kotlin/com/thelightphone/plugin/AudioDashCapabilityTest.kt
+++ b/plugin/src/test/kotlin/com/thelightphone/plugin/AudioDashCapabilityTest.kt
@@ -1,0 +1,77 @@
+package com.thelightphone.plugin
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.nio.file.Path
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class AudioDashCapabilityTest {
+
+    private fun writeToml(dir: Path, capabilities: String): File {
+        val file = dir.resolve("lighttool.toml").toFile()
+        file.writeText(
+            """
+            [tool]
+            id = "com.example.mytool"
+            label = "My Tool"
+            versionCode = 1
+            versionName = "1.0.0"
+            capabilities = [$capabilities]
+            serverPackage = "com.lightos"
+            """.trimIndent()
+        )
+        return file
+    }
+
+    @Test
+    fun `audio-dash is a declarable capability`(@TempDir dir: Path) {
+        val meta = LightToolMetadata.parse(writeToml(dir, "\"audio-dash\""))
+
+        assertEquals(listOf("audio-dash"), meta.capabilities)
+    }
+
+    @Test
+    fun `audio-dash combines with detached audio`(@TempDir dir: Path) {
+        val meta = LightToolMetadata.parse(writeToml(dir, "\"detached-audio\", \"audio-dash\""))
+
+        assertEquals(listOf("detached-audio", "audio-dash"), meta.capabilities)
+    }
+
+    @Test
+    fun `an unknown audio capability is rejected`(@TempDir dir: Path) {
+        val ex = assertThrows<LightToolMetadataException> {
+            LightToolMetadata.parse(writeToml(dir, "\"audio-hls\""))
+        }
+
+        assertTrue(ex.message!!.contains("capability not allowed: audio-hls"))
+    }
+
+    @Test
+    fun `audio-dash contributes the media3 dash source`() {
+        assertEquals(
+            listOf("androidx.media3:media3-exoplayer-dash:${LightToolPolicy.MEDIA3_VERSION}"),
+            LightToolPolicy.CAPABILITY_IMPLIED_DEPENDENCIES[LightToolPolicy.AUDIO_DASH],
+        )
+    }
+
+    /**
+     * A tool resolving one media3 version for the SDK and another for its DASH
+     * source is the failure this guards, and nothing in the build would catch
+     * it: both versions exist and both resolve.
+     */
+    @Test
+    fun `the hardcoded media3 version tracks the version catalog`() {
+        val catalog = File(System.getProperty("light.versionCatalog"))
+        assertTrue(catalog.isFile, "version catalog not found at ${catalog.path}")
+
+        val declared = Regex("""^media3\s*=\s*"([^"]+)"""", RegexOption.MULTILINE)
+            .find(catalog.readText())
+            ?.groupValues
+            ?.get(1)
+
+        assertEquals(declared, LightToolPolicy.MEDIA3_VERSION)
+    }
+}

--- a/plugin/src/test/kotlin/com/thelightphone/plugin/AudioDashCapabilityTest.kt
+++ b/plugin/src/test/kotlin/com/thelightphone/plugin/AudioDashCapabilityTest.kt
@@ -57,11 +57,7 @@ class AudioDashCapabilityTest {
         )
     }
 
-    /**
-     * A tool resolving one media3 version for the SDK and another for its DASH
-     * source is the failure this guards, and nothing in the build would catch
-     * it: both versions exist and both resolve.
-     */
+    /** Keep the plugin's media3 version in sync with the catalog. */
     @Test
     fun `the hardcoded media3 version tracks the version catalog`() {
         val catalog = File(System.getProperty("light.versionCatalog"))

--- a/sdk/client/README.md
+++ b/sdk/client/README.md
@@ -129,12 +129,60 @@ player.play()
 
 - Use `pause`, `stop`, and `seekTo` for transport controls.
 - `skipBack()` and `skipForward()` seek 15 seconds within the current item; `skipToPrevious()` and `skipToNext()` move through the queue.
+- Edit the queue in place with `addMediaItem`, `removeMediaItem`, `moveMediaItem`, and `replaceMediaItem`. `mediaItemCount` reports its length.
 - Set `speed` to change playback rate; values at or below zero clamp to the minimum supported rate.
 - Use `setSource(File)` as a convenience for a one-item local-file queue.
 - Playback requests audio focus automatically.
 - If focus is unavailable, `play()` does nothing.
 - Observe `isPlaying` for the actual state.
 - Transient focus loss pauses and later resumes playback, while duckable loss lowers the volume.
+
+##### Editing the queue
+
+A negative index is a mistake and throws. An index past the end is not: a queue can change underneath a tool, so `addMediaItem` appends, `moveMediaItem` clamps its destination to the end, and everything else does nothing.
+
+`replaceMediaItem` swaps an item's source while the queue keeps playing, which is how to hand the player a re-resolved URL for audio that is already loaded. Give both items the same `LightAudioItem.id` so they name the same audio:
+
+```kotlin
+val track = LightAudioItem(
+    id = "track-1",
+    source = LightAudioSource.UrlSource(freshUrl),
+    metadata = LightMediaMetadata(title = "Example"),
+)
+player.replaceMediaItem(index, track)
+```
+
+An item without an `id` is identified by its location, which is right whenever the location is stable.
+
+##### Caching what you stream
+
+A player can read through caches the tool describes. The SDK opens each store under your tool's private storage, shares one per directory across your process, and keeps it when the player is released:
+
+```kotlin
+val player = audio.newPlayer(
+    caches = listOf(
+        LightMediaCache("stream", LightCacheEviction.LeastRecentlyUsed(256L * 1024 * 1024)),
+        LightMediaCache("saved", LightCacheEviction.Never),
+    ),
+)
+```
+
+Caches are consulted in the order given, and only then the network. Newly streamed bytes are written to the size-limited cache, so at most one cache may be size-limited and a player without one caches nothing it streams. A cache that never evicts is only read during playback; what goes in it is up to the tool.
+
+Cached bytes are filed under `LightAudioItem.id`, so an item whose URL is re-resolved still finds what it already cached. Files and bundled assets bypass caching, since they are already on the device.
+
+A detached session's caches are fixed when its player is built. Reconnecting with a different set throws `LightAudioPlayerException`, the same way a conflicting `LightAudioUsage` does.
+
+##### Streaming DASH
+
+media3 plays DASH only when a source for it is on the classpath, which the SDK does not ship to every tool. Ask for it in `lighttool.toml`:
+
+```toml
+[tool]
+capabilities = ["audio-dash"]
+```
+
+Nothing else changes: pass the manifest URL as a `LightAudioSource.UrlSource` and the player selects the DASH source itself.
 
 ##### Playback failures
 

--- a/sdk/client/README.md
+++ b/sdk/client/README.md
@@ -188,13 +188,11 @@ val player = audio.newPlayer(
 )
 ```
 
-A source factory replaces the SDK's read path rather than layering onto it, since a tool reaching for one has already said media3 cannot fetch this audio. Requested caches are still opened and handed over in `env`, so the tool can bank into the same stores playback reads from. That also means the tool decides what it writes, and the one-size-limited-cache rule does not apply.
+A source factory replaces the SDK's HTTP read path. Requested caches are still opened and handed over in `env`. The one-size-limited-cache rule does not apply.
 
-The SDK keeps the output half either way: audio attributes, focus, the media session, and the queue belong to the player it builds.
+Do not capture UI state: in detached playback the factory runs inside the service. Reconnecting to a live session must pass `sourceFactory = null`.
 
-Because construction happens inside the service for detached playback, the factory outlives the screen that installed it and must not capture UI state. A live detached session already has its read path, so reconnecting to one must pass `sourceFactory = null`; anything else throws `LightAudioPlayerException`.
-
-Using this means working with media3 types (`MediaSource.Factory`, `Cache`, `DataSource.Factory`) directly, which is why they are exposed rather than hidden. Tools that only play URLs never need it.
+This exposes media3 types (`MediaSource.Factory`, `Cache`, `DataSource.Factory`). Tools that only play URLs never need it.
 
 ##### Streaming DASH
 

--- a/sdk/client/README.md
+++ b/sdk/client/README.md
@@ -167,11 +167,34 @@ val player = audio.newPlayer(
 )
 ```
 
-Caches are consulted in the order given, and only then the network. Newly streamed bytes are written to the size-limited cache, so at most one cache may be size-limited and a player without one caches nothing it streams. A cache that never evicts is only read during playback; what goes in it is up to the tool.
+Caches are consulted in the order given, and only then the network. Newly streamed bytes are written to the size-limited cache, so at most one cache may be size-limited and a player without one caches nothing it streams. The SDK never writes to a cache that never evicts, since streaming into one would pin every byte played; filling it is the tool's decision, through a source factory or by writing the store directly.
 
 Cached bytes are filed under `LightAudioItem.id`, so an item whose URL is re-resolved still finds what it already cached. Files and bundled assets bypass caching, since they are already on the device.
 
 A detached session's caches are fixed when its player is built. Reconnecting with a different set throws `LightAudioPlayerException`, the same way a conflicting `LightAudioUsage` does.
+
+##### Audio media3 cannot fetch
+
+A cache says where bytes are kept, which is enough when media3 can fetch them itself. Audio that has to be decrypted or pulled out of a session your tool owns cannot be described that way, so supply the read path instead:
+
+```kotlin
+val player = audio.newPlayer(
+    caches = listOf(LightMediaCache("stream", LightCacheEviction.LeastRecentlyUsed(64L * 1024 * 1024))),
+    sourceFactory = { env ->
+        // env.caches["stream"] is already open; env.dataSourceFactory reads
+        // files, assets, and HTTP with no caching of its own.
+        MyDecryptingMediaSourceFactory(env.caches.getValue("stream"))
+    },
+)
+```
+
+A source factory replaces the SDK's read path rather than layering onto it, since a tool reaching for one has already said media3 cannot fetch this audio. Requested caches are still opened and handed over in `env`, so the tool can bank into the same stores playback reads from. That also means the tool decides what it writes, and the one-size-limited-cache rule does not apply.
+
+The SDK keeps the output half either way: audio attributes, focus, the media session, and the queue belong to the player it builds.
+
+Because construction happens inside the service for detached playback, the factory outlives the screen that installed it and must not capture UI state. A live detached session already has its read path, so reconnecting to one must pass `sourceFactory = null`; anything else throws `LightAudioPlayerException`.
+
+Using this means working with media3 types (`MediaSource.Factory`, `Cache`, `DataSource.Factory`) directly, which is why they are exposed rather than hidden. Tools that only play URLs never need it.
 
 ##### Streaming DASH
 

--- a/sdk/client/build.gradle.kts
+++ b/sdk/client/build.gradle.kts
@@ -65,6 +65,8 @@ dependencies {
     implementation(libs.androidx.media3.common)
     implementation(libs.androidx.media3.exoplayer)
     implementation(libs.androidx.media3.session)
+    implementation(libs.androidx.media3.datasource)
+    implementation(libs.androidx.media3.database)
     lintChecks(project(":lint-rules"))
 
     testImplementation(libs.kotlin.test)

--- a/sdk/client/build.gradle.kts
+++ b/sdk/client/build.gradle.kts
@@ -62,9 +62,7 @@ dependencies {
     api(libs.androidx.room.runtime)
     api(libs.androidx.room.ktx)
     implementation(libs.androidx.work.runtime)
-    // api, not implementation: LightMediaSourceFactory hands tools a media3
-    // MediaSource.Factory and opened Cache, so those types are part of the
-    // audio API for any tool whose audio media3 cannot fetch by itself.
+    // api: LightMediaSourceFactory exposes media3 types to tools.
     api(libs.androidx.media3.common)
     api(libs.androidx.media3.exoplayer)
     api(libs.androidx.media3.datasource)

--- a/sdk/client/build.gradle.kts
+++ b/sdk/client/build.gradle.kts
@@ -62,10 +62,13 @@ dependencies {
     api(libs.androidx.room.runtime)
     api(libs.androidx.room.ktx)
     implementation(libs.androidx.work.runtime)
-    implementation(libs.androidx.media3.common)
-    implementation(libs.androidx.media3.exoplayer)
+    // api, not implementation: LightMediaSourceFactory hands tools a media3
+    // MediaSource.Factory and opened Cache, so those types are part of the
+    // audio API for any tool whose audio media3 cannot fetch by itself.
+    api(libs.androidx.media3.common)
+    api(libs.androidx.media3.exoplayer)
+    api(libs.androidx.media3.datasource)
     implementation(libs.androidx.media3.session)
-    implementation(libs.androidx.media3.datasource)
     implementation(libs.androidx.media3.database)
     lintChecks(project(":lint-rules"))
 

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/AudioTypes.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/AudioTypes.kt
@@ -216,11 +216,8 @@ sealed interface LightAudioSource {
  *
  * @property source playable media location
  * @property metadata descriptive values forwarded to playback surfaces
- * @property id stable identity for this entry, unique within the queue. Give
- *   one when [source] can change while still naming the same audio — an expiring
- *   stream URL replaced through [LightAudioPlayer.replaceMediaItem] is the same
- *   track, and only a stable id can say so. Defaults to the source location,
- *   which is right whenever the location is the identity.
+ * @property id stable identity, unique within the queue. Use when [source] can
+ *   change while naming the same audio. Defaults to the source location.
  */
 data class LightAudioItem(
     val source: LightAudioSource,

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/AudioTypes.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/AudioTypes.kt
@@ -216,10 +216,16 @@ sealed interface LightAudioSource {
  *
  * @property source playable media location
  * @property metadata descriptive values forwarded to playback surfaces
+ * @property id stable identity for this entry, unique within the queue. Give
+ *   one when [source] can change while still naming the same audio — an expiring
+ *   stream URL replaced through [LightAudioPlayer.replaceMediaItem] is the same
+ *   track, and only a stable id can say so. Defaults to the source location,
+ *   which is right whenever the location is the identity.
  */
 data class LightAudioItem(
     val source: LightAudioSource,
     val metadata: LightMediaMetadata,
+    val id: String? = null,
 )
 
 internal const val DEFAULT_SAMPLE_RATE = 48_000

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/DetachedSessionState.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/DetachedSessionState.kt
@@ -1,5 +1,8 @@
 package com.thelightphone.sdk.audio
 
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+
 /**
  * The one detached session a tool process can have.
  *
@@ -22,11 +25,14 @@ package com.thelightphone.sdk.audio
  * would stop itself 60s into any pause with a tool still attached. The service
  * asserts its process on startup rather than letting that happen quietly.
  */
+@OptIn(UnstableApi::class)
 internal class DetachedSessionState {
     private var handleOpen = false
     private var sessionUsage: LightAudioUsage? = null
     private var stagedCaches: List<LightMediaCache> = emptyList()
     private var sessionCaches: List<LightMediaCache>? = null
+    private var stagedSourceFactory: LightMediaSourceFactory? = null
+    private var sessionHasSourceFactory: Boolean? = null
     private var handleChanged: (() -> Unit)? = null
 
     /** Takes the single detached handle, or fails when one is already out. */
@@ -71,6 +77,8 @@ internal class DetachedSessionState {
         sessionUsage = null
         sessionCaches = null
         stagedCaches = emptyList()
+        sessionHasSourceFactory = null
+        stagedSourceFactory = null
     }
 
     /** The live session's usage, or `null` when no session is running. */
@@ -104,6 +112,33 @@ internal class DetachedSessionState {
     /** The live session's caches, or `null` when no session is running. */
     @Synchronized
     fun activeCaches(): List<LightMediaCache>? = sessionCaches
+
+    /** Leaves the source factory a starting service should build its player with. */
+    @Synchronized
+    fun stageSourceFactory(factory: LightMediaSourceFactory?) {
+        stagedSourceFactory = factory
+    }
+
+    /** Service side: the factory left for the player being constructed. */
+    @Synchronized
+    fun stagedSourceFactory(): LightMediaSourceFactory? = stagedSourceFactory
+
+    /**
+     * Service side: the live session settled on its read path.
+     *
+     * Only whether there was a factory is kept. The factory itself is dropped,
+     * because holding a tool's lambda past construction would outlive the screen
+     * that supplied it for no gain: it can never be applied to a second player.
+     */
+    @Synchronized
+    fun adoptSourceFactory(present: Boolean) {
+        sessionHasSourceFactory = present
+        stagedSourceFactory = null
+    }
+
+    /** Whether the live session has a custom read path, or `null` when idle. */
+    @Synchronized
+    fun activeSourceFactoryPresence(): Boolean? = sessionHasSourceFactory
 }
 
 internal val detachedSessionState = DetachedSessionState()
@@ -126,3 +161,18 @@ internal fun isDetachedCacheCompatible(
     activeCaches: List<LightMediaCache>?,
     requestedCaches: List<LightMediaCache>,
 ): Boolean = activeCaches == null || activeCaches == requestedCaches
+
+/**
+ * Whether a connecting handle may bring a source factory.
+ *
+ * Caches can be compared, so a reconnect that asks for the same ones is allowed
+ * through. Two factories that would build the same pipeline are
+ * indistinguishable from two that would not, so there is no equivalent check to
+ * make: reconnecting to a live session means accepting the read path it already
+ * has, and the only honest way to say that is to require no factory at all.
+ */
+@OptIn(UnstableApi::class)
+internal fun isDetachedSourceFactoryCompatible(
+    activeSourceFactoryPresence: Boolean?,
+    requestedFactory: LightMediaSourceFactory?,
+): Boolean = activeSourceFactoryPresence == null || requestedFactory == null

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/DetachedSessionState.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/DetachedSessionState.kt
@@ -25,6 +25,8 @@ package com.thelightphone.sdk.audio
 internal class DetachedSessionState {
     private var handleOpen = false
     private var sessionUsage: LightAudioUsage? = null
+    private var stagedCaches: List<LightMediaCache> = emptyList()
+    private var sessionCaches: List<LightMediaCache>? = null
     private var handleChanged: (() -> Unit)? = null
 
     /** Takes the single detached handle, or fails when one is already out. */
@@ -67,11 +69,41 @@ internal class DetachedSessionState {
     @Synchronized
     fun clearSession() {
         sessionUsage = null
+        sessionCaches = null
+        stagedCaches = emptyList()
     }
 
     /** The live session's usage, or `null` when no session is running. */
     @Synchronized
     fun activeUsage(): LightAudioUsage? = sessionUsage
+
+    /**
+     * Leaves the caches a starting service should build its player with.
+     *
+     * Connection hints cannot carry these. The system constructs the service and
+     * `onCreate` builds the player there, which happens before any controller
+     * connects — so the only channel that arrives in time is this process-local
+     * state, written by `newPlayer` before it asks for a controller at all.
+     */
+    @Synchronized
+    fun stageCaches(caches: List<LightMediaCache>) {
+        stagedCaches = caches
+    }
+
+    /** Service side: the caches left for the player being constructed. */
+    @Synchronized
+    fun stagedCaches(): List<LightMediaCache> = stagedCaches
+
+    /** Service side: the live session settled on the caches it was built with. */
+    @Synchronized
+    fun adoptCaches(caches: List<LightMediaCache>) {
+        sessionCaches = caches
+        stagedCaches = emptyList()
+    }
+
+    /** The live session's caches, or `null` when no session is running. */
+    @Synchronized
+    fun activeCaches(): List<LightMediaCache>? = sessionCaches
 }
 
 internal val detachedSessionState = DetachedSessionState()
@@ -80,3 +112,17 @@ internal fun isDetachedUsageCompatible(
     activeUsage: LightAudioUsage?,
     requestedUsage: LightAudioUsage,
 ): Boolean = activeUsage == null || activeUsage == requestedUsage
+
+/**
+ * Whether a connecting handle's caches match the ones the live session was
+ * built with.
+ *
+ * A live session already has its player, and a player cannot be told to read
+ * from somewhere else afterwards. Asking is therefore either redundant or
+ * impossible, and the difference is worth a thrown error rather than a player
+ * that quietly caches nothing the tool asked for.
+ */
+internal fun isDetachedCacheCompatible(
+    activeCaches: List<LightMediaCache>?,
+    requestedCaches: List<LightMediaCache>,
+): Boolean = activeCaches == null || activeCaches == requestedCaches

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/DetachedSessionState.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/DetachedSessionState.kt
@@ -85,14 +85,7 @@ internal class DetachedSessionState {
     @Synchronized
     fun activeUsage(): LightAudioUsage? = sessionUsage
 
-    /**
-     * Leaves the caches a starting service should build its player with.
-     *
-     * Connection hints cannot carry these. The system constructs the service and
-     * `onCreate` builds the player there, which happens before any controller
-     * connects — so the only channel that arrives in time is this process-local
-     * state, written by `newPlayer` before it asks for a controller at all.
-     */
+    /** Staged for the service to read in `onCreate`. */
     @Synchronized
     fun stageCaches(caches: List<LightMediaCache>) {
         stagedCaches = caches
@@ -113,23 +106,16 @@ internal class DetachedSessionState {
     @Synchronized
     fun activeCaches(): List<LightMediaCache>? = sessionCaches
 
-    /** Leaves the source factory a starting service should build its player with. */
+    /** Staged for the service to read in `onCreate`. */
     @Synchronized
     fun stageSourceFactory(factory: LightMediaSourceFactory?) {
         stagedSourceFactory = factory
     }
 
-    /** Service side: the factory left for the player being constructed. */
     @Synchronized
     fun stagedSourceFactory(): LightMediaSourceFactory? = stagedSourceFactory
 
-    /**
-     * Service side: the live session settled on its read path.
-     *
-     * Only whether there was a factory is kept. The factory itself is dropped,
-     * because holding a tool's lambda past construction would outlive the screen
-     * that supplied it for no gain: it can never be applied to a second player.
-     */
+    /** Records whether a factory was used, then drops the lambda. */
     @Synchronized
     fun adoptSourceFactory(present: Boolean) {
         sessionHasSourceFactory = present
@@ -148,29 +134,12 @@ internal fun isDetachedUsageCompatible(
     requestedUsage: LightAudioUsage,
 ): Boolean = activeUsage == null || activeUsage == requestedUsage
 
-/**
- * Whether a connecting handle's caches match the ones the live session was
- * built with.
- *
- * A live session already has its player, and a player cannot be told to read
- * from somewhere else afterwards. Asking is therefore either redundant or
- * impossible, and the difference is worth a thrown error rather than a player
- * that quietly caches nothing the tool asked for.
- */
 internal fun isDetachedCacheCompatible(
     activeCaches: List<LightMediaCache>?,
     requestedCaches: List<LightMediaCache>,
 ): Boolean = activeCaches == null || activeCaches == requestedCaches
 
-/**
- * Whether a connecting handle may bring a source factory.
- *
- * Caches can be compared, so a reconnect that asks for the same ones is allowed
- * through. Two factories that would build the same pipeline are
- * indistinguishable from two that would not, so there is no equivalent check to
- * make: reconnecting to a live session means accepting the read path it already
- * has, and the only honest way to say that is to require no factory at all.
- */
+/** Live sessions already have a factory; reconnect must pass none. */
 @OptIn(UnstableApi::class)
 internal fun isDetachedSourceFactoryCompatible(
     activeSourceFactoryPresence: Boolean?,

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudio.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudio.kt
@@ -2,14 +2,19 @@ package com.thelightphone.sdk.audio
 
 import android.content.Context
 import android.media.AudioManager
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
 import com.thelightphone.sdk.SealedLightActivity
 
 interface LightAudio {
     val capabilities: AudioCapabilities
+
+    @OptIn(UnstableApi::class)
     fun newPlayer(
         usage: LightAudioUsage = LightAudioUsage.Music,
         playback: LightAudioPlayback = LightAudioPlayback.Attached,
         caches: List<LightMediaCache> = emptyList(),
+        sourceFactory: LightMediaSourceFactory? = null,
     ): LightAudioPlayer
     fun newRecorder(cfg: RecorderConfig = RecorderConfig()): LightAudioRecorder
     fun newCapture(cfg: CaptureConfig = CaptureConfig()): LightAudioCapture
@@ -32,19 +37,24 @@ value class DefaultLightAudio(
      * Create a player that requests audio focus appropriate for [usage], reading
      * through [caches] in the order given before reaching the network.
      *
+     * Pass a [sourceFactory] for audio media3 cannot fetch on its own; it
+     * replaces that read path and receives the opened [caches].
+     *
      * Only one [LightAudioPlayback.Detached] player handle may exist in the
      * process at a time. Reconnecting to a live detached session cannot change
      * where that session's player reads from, so [caches] must match the ones it
-     * was built with.
+     * was built with and [sourceFactory] must be null.
      */
+    @OptIn(UnstableApi::class)
     override fun newPlayer(
         usage: LightAudioUsage,
         playback: LightAudioPlayback,
         caches: List<LightMediaCache>,
+        sourceFactory: LightMediaSourceFactory?,
     ): LightAudioPlayer {
-        validateMediaCaches(caches)
+        validateMediaCaches(caches, hasCustomSource = sourceFactory != null)
         if (playback == LightAudioPlayback.Attached) {
-            return LightAudioPlayer(sealedActivity.activity, usage, playback, caches)
+            return LightAudioPlayer(sealedActivity.activity, usage, playback, caches, sourceFactory)
         }
 
         sealedActivity.activity.requireDetachedAudioCapability()
@@ -63,6 +73,15 @@ value class DefaultLightAudio(
                     "stop the detached session first."
             )
         }
+        val activeSourceFactory = detachedSessionState.activeSourceFactoryPresence()
+        if (!isDetachedSourceFactoryCompatible(activeSourceFactory, sourceFactory)) {
+            throw LightAudioPlayerException(
+                "Detached audio already built its player" +
+                    (if (activeSourceFactory == true) " with a source factory" else "") +
+                    ", so a reconnecting player cannot supply one. " +
+                    "Reconnect without a sourceFactory or stop the detached session first."
+            )
+        }
         if (!detachedSessionState.openHandle()) {
             throw LightAudioPlayerException(
                 "Only one detached LightAudioPlayer may exist at a time; release the existing player first"
@@ -71,12 +90,14 @@ value class DefaultLightAudio(
         // Staged before the controller is built, because building it is what
         // starts the service that reads this.
         detachedSessionState.stageCaches(caches)
+        detachedSessionState.stageSourceFactory(sourceFactory)
         return try {
             LightAudioPlayer(
                 sealedActivity.activity,
                 usage,
                 playback,
                 caches,
+                sourceFactory,
                 detachedSessionState::closeHandle,
             )
         } catch (error: Throwable) {

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudio.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudio.kt
@@ -9,6 +9,7 @@ interface LightAudio {
     fun newPlayer(
         usage: LightAudioUsage = LightAudioUsage.Music,
         playback: LightAudioPlayback = LightAudioPlayback.Attached,
+        caches: List<LightMediaCache> = emptyList(),
     ): LightAudioPlayer
     fun newRecorder(cfg: RecorderConfig = RecorderConfig()): LightAudioRecorder
     fun newCapture(cfg: CaptureConfig = CaptureConfig()): LightAudioCapture
@@ -28,17 +29,22 @@ value class DefaultLightAudio(
         get() = sealedActivity.activity.readAudioCapabilities()
 
     /**
-     * Create a player that requests audio focus appropriate for [usage].
+     * Create a player that requests audio focus appropriate for [usage], reading
+     * through [caches] in the order given before reaching the network.
      *
      * Only one [LightAudioPlayback.Detached] player handle may exist in the
-     * process at a time.
+     * process at a time. Reconnecting to a live detached session cannot change
+     * where that session's player reads from, so [caches] must match the ones it
+     * was built with.
      */
     override fun newPlayer(
         usage: LightAudioUsage,
         playback: LightAudioPlayback,
+        caches: List<LightMediaCache>,
     ): LightAudioPlayer {
+        validateMediaCaches(caches)
         if (playback == LightAudioPlayback.Attached) {
-            return LightAudioPlayer(sealedActivity.activity, usage, playback)
+            return LightAudioPlayer(sealedActivity.activity, usage, playback, caches)
         }
 
         sealedActivity.activity.requireDetachedAudioCapability()
@@ -49,16 +55,28 @@ value class DefaultLightAudio(
                     "Reconnect with the active usage or wait for the detached session to stop."
             )
         }
+        val activeCaches = detachedSessionState.activeCaches()
+        if (!isDetachedCacheCompatible(activeCaches, caches)) {
+            throw LightAudioPlayerException(
+                "Detached audio is already reading through $activeCaches; requested $caches. " +
+                    "Its player is already built, so reconnect with the active caches or " +
+                    "stop the detached session first."
+            )
+        }
         if (!detachedSessionState.openHandle()) {
             throw LightAudioPlayerException(
                 "Only one detached LightAudioPlayer may exist at a time; release the existing player first"
             )
         }
+        // Staged before the controller is built, because building it is what
+        // starts the service that reads this.
+        detachedSessionState.stageCaches(caches)
         return try {
             LightAudioPlayer(
                 sealedActivity.activity,
                 usage,
                 playback,
+                caches,
                 detachedSessionState::closeHandle,
             )
         } catch (error: Throwable) {

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudio.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudio.kt
@@ -87,8 +87,6 @@ value class DefaultLightAudio(
                 "Only one detached LightAudioPlayer may exist at a time; release the existing player first"
             )
         }
-        // Staged before the controller is built, because building it is what
-        // starts the service that reads this.
         detachedSessionState.stageCaches(caches)
         detachedSessionState.stageSourceFactory(sourceFactory)
         return try {

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudioPlayer.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudioPlayer.kt
@@ -3,6 +3,7 @@ package com.thelightphone.sdk.audio
 import android.content.ComponentName
 import android.content.Context
 import android.net.Uri
+import androidx.annotation.OptIn
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
@@ -10,7 +11,7 @@ import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.Timeline
-import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
 import java.io.File
@@ -45,6 +46,7 @@ class LightAudioPlayer internal constructor(
     context: Context,
     usage: LightAudioUsage = LightAudioUsage.Music,
     internal val playback: LightAudioPlayback = LightAudioPlayback.Attached,
+    caches: List<LightMediaCache> = emptyList(),
     private val onRelease: () -> Unit = {},
 ) {
     private val scopeJob = SupervisorJob()
@@ -78,11 +80,9 @@ class LightAudioPlayer internal constructor(
 
     init {
         when (playback) {
-            LightAudioPlayback.Attached -> connectPlayer(
-                ExoPlayer.Builder(context).build().apply {
-                    setAudioAttributes(usage.toMedia3AudioAttributes(), true)
-                },
-            )
+            LightAudioPlayback.Attached ->
+                connectPlayer(buildSdkExoPlayer(context, usage, caches))
+            // The detached player was built by the service from staged caches.
             LightAudioPlayback.Detached -> connectDetachedPlayer(context, usage)
         }
     }
@@ -409,9 +409,13 @@ internal suspend fun awaitPlayerReady(
 ): Boolean = availability.first { it != LightAudioPlayerAvailability.Initializing } ==
     LightAudioPlayerAvailability.Ready
 
+@OptIn(UnstableApi::class)
 internal fun LightAudioItem.toMediaItem(): MediaItem = MediaItem.Builder()
     .setUri(Uri.parse(source.uriString()))
     .setMediaId(stableId())
+    // Files cached bytes under the item's identity rather than its location, so
+    // a re-resolved URL still finds what the old one cached.
+    .setCustomCacheKey(stableId())
     .setMediaMetadata(metadata.toMedia3Metadata())
     .build()
 

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudioPlayer.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudioPlayer.kt
@@ -84,7 +84,6 @@ class LightAudioPlayer internal constructor(
         when (playback) {
             LightAudioPlayback.Attached ->
                 connectPlayer(buildSdkExoPlayer(context, usage, caches, sourceFactory))
-            // The detached player was built by the service from staged caches.
             LightAudioPlayback.Detached -> connectDetachedPlayer(context, usage)
         }
     }
@@ -273,12 +272,8 @@ class LightAudioPlayer internal constructor(
 
     /**
      * Replaces the item at [index] with [item]. An [index] past the end changes
-     * nothing.
-     *
-     * Replacing the current item keeps playing it until the new source is ready,
-     * which is what makes this the way to swap in a re-resolved URL for audio
-     * that is already playing. Give both items the same [LightAudioItem.id] so
-     * the swap reads as one continuing track rather than two.
+     * nothing. Give both items the same [LightAudioItem.id] when swapping a
+     * re-resolved URL for audio that is already playing.
      *
      * @throws IllegalArgumentException when [index] is negative
      */
@@ -397,10 +392,7 @@ class LightAudioPlayer internal constructor(
         _durationMs.value = state.durationMs
     }
 
-    /**
-     * A player that has never been prepared, or was stopped, ignores its queue
-     * until asked again. Adding to such a queue reads as "play this", so ask.
-     */
+    /** Prepare after a mutation if the player is idle. */
     private fun prepareIfIdle(player: Player) {
         if (player.playbackState == Player.STATE_IDLE) player.prepare()
     }
@@ -415,8 +407,6 @@ internal suspend fun awaitPlayerReady(
 internal fun LightAudioItem.toMediaItem(): MediaItem = MediaItem.Builder()
     .setUri(Uri.parse(source.uriString()))
     .setMediaId(stableId())
-    // Files cached bytes under the item's identity rather than its location, so
-    // a re-resolved URL still finds what the old one cached.
     .setCustomCacheKey(stableId())
     .setMediaMetadata(metadata.toMedia3Metadata())
     .build()

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudioPlayer.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudioPlayer.kt
@@ -9,6 +9,7 @@ import androidx.media3.common.MediaMetadata
 import androidx.media3.common.PlaybackParameters
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
+import androidx.media3.common.Timeline
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaController
 import androidx.media3.session.SessionToken
@@ -52,6 +53,7 @@ class LightAudioPlayer internal constructor(
     private val _durationMs = MutableStateFlow(0L)
     private val _isPlaying = MutableStateFlow(false)
     private val _currentMediaItemIndex = MutableStateFlow(NO_MEDIA_ITEM)
+    private val _mediaItemCount = MutableStateFlow(0)
     private val _error = MutableStateFlow<LightAudioError?>(null)
     private val commands = PendingPlayerCommands()
     private var positionJob: Job? = null
@@ -67,6 +69,8 @@ class LightAudioPlayer internal constructor(
     val isPlaying: StateFlow<Boolean> = _isPlaying.asStateFlow()
     /** Current queue index, or `-1` when the queue is empty. */
     val currentMediaItemIndex: StateFlow<Int> = _currentMediaItemIndex.asStateFlow()
+    /** Number of items in the queue, including ones added by another controller. */
+    val mediaItemCount: StateFlow<Int> = _mediaItemCount.asStateFlow()
     /** Current playback failure, or `null` after successful re-preparation. */
     val error: StateFlow<LightAudioError?> = _error.asStateFlow()
     /** Connection and command-acceptance lifecycle of this player. */
@@ -98,6 +102,12 @@ class LightAudioPlayer internal constructor(
                 }
             }
 
+            // Editing the queue can move the current item without transitioning to
+            // it, and in detached mode another controller may edit it at any time.
+            override fun onTimelineChanged(timeline: Timeline, reason: Int) {
+                refreshQueueState(connectedPlayer)
+            }
+
             override fun onIsPlayingChanged(isPlaying: Boolean) {
                 _isPlaying.value = isPlaying
                 if (isPlaying) {
@@ -122,6 +132,7 @@ class LightAudioPlayer internal constructor(
         })
         val state = connectedPlayer.snapshotState()
         _currentMediaItemIndex.value = state.currentMediaItemIndex
+        _mediaItemCount.value = state.mediaItemCount
         _positionMs.value = state.positionMs
         _durationMs.value = state.durationMs
         _isPlaying.value = state.isPlaying
@@ -192,13 +203,88 @@ class LightAudioPlayer internal constructor(
             return
         }
         require(startIndex in items.indices) { "Start index must reference a queue item" }
-        val mediaItems = items.mapIndexed { index, item -> item.toMediaItem(index) }
+        val mediaItems = items.map(LightAudioItem::toMediaItem)
         commands.dispatch { player ->
             player.setMediaItems(mediaItems, startIndex, C.TIME_UNSET)
             _currentMediaItemIndex.value = startIndex
             player.prepare()
             updateDuration(player)
             updatePosition(player)
+        }
+    }
+
+    /**
+     * Appends [item] to the queue, preparing playback when the queue was idle.
+     */
+    fun addMediaItem(item: LightAudioItem) {
+        val mediaItem = item.toMediaItem()
+        commands.dispatch { player ->
+            player.addMediaItem(mediaItem)
+            prepareIfIdle(player)
+        }
+    }
+
+    /**
+     * Inserts [item] at [index], shifting later items back. An [index] past the
+     * end appends.
+     *
+     * @throws IllegalArgumentException when [index] is negative
+     */
+    fun addMediaItem(index: Int, item: LightAudioItem) {
+        require(index >= 0) { "Queue index must not be negative" }
+        val mediaItem = item.toMediaItem()
+        commands.dispatch { player ->
+            player.addMediaItem(index.coerceAtMost(player.mediaItemCount), mediaItem)
+            prepareIfIdle(player)
+        }
+    }
+
+    /**
+     * Removes the item at [index]. Removing the current item advances to the
+     * next one. An [index] past the end changes nothing.
+     *
+     * @throws IllegalArgumentException when [index] is negative
+     */
+    fun removeMediaItem(index: Int) {
+        require(index >= 0) { "Queue index must not be negative" }
+        commands.dispatch { player ->
+            if (index < player.mediaItemCount) player.removeMediaItem(index)
+        }
+    }
+
+    /**
+     * Moves the item at [fromIndex] to [toIndex] without interrupting playback
+     * of the current item. A [toIndex] past the end moves to the end, and a
+     * [fromIndex] past the end changes nothing.
+     *
+     * @throws IllegalArgumentException when either index is negative
+     */
+    fun moveMediaItem(fromIndex: Int, toIndex: Int) {
+        require(fromIndex >= 0 && toIndex >= 0) { "Queue indices must not be negative" }
+        commands.dispatch { player ->
+            val lastIndex = player.mediaItemCount - 1
+            if (fromIndex <= lastIndex) {
+                player.moveMediaItem(fromIndex, toIndex.coerceAtMost(lastIndex))
+            }
+        }
+    }
+
+    /**
+     * Replaces the item at [index] with [item]. An [index] past the end changes
+     * nothing.
+     *
+     * Replacing the current item keeps playing it until the new source is ready,
+     * which is what makes this the way to swap in a re-resolved URL for audio
+     * that is already playing. Give both items the same [LightAudioItem.id] so
+     * the swap reads as one continuing track rather than two.
+     *
+     * @throws IllegalArgumentException when [index] is negative
+     */
+    fun replaceMediaItem(index: Int, item: LightAudioItem) {
+        require(index >= 0) { "Queue index must not be negative" }
+        val mediaItem = item.toMediaItem()
+        commands.dispatch { player ->
+            if (index < player.mediaItemCount) player.replaceMediaItem(index, mediaItem)
         }
     }
 
@@ -301,6 +387,21 @@ class LightAudioPlayer internal constructor(
     private fun updateDuration(player: Player) {
         _durationMs.value = player.duration.validDuration()
     }
+
+    private fun refreshQueueState(player: Player) {
+        val state = player.snapshotState()
+        _mediaItemCount.value = state.mediaItemCount
+        _currentMediaItemIndex.value = state.currentMediaItemIndex
+        _durationMs.value = state.durationMs
+    }
+
+    /**
+     * A player that has never been prepared, or was stopped, ignores its queue
+     * until asked again. Adding to such a queue reads as "play this", so ask.
+     */
+    private fun prepareIfIdle(player: Player) {
+        if (player.playbackState == Player.STATE_IDLE) player.prepare()
+    }
 }
 
 internal suspend fun awaitPlayerReady(
@@ -308,14 +409,14 @@ internal suspend fun awaitPlayerReady(
 ): Boolean = availability.first { it != LightAudioPlayerAvailability.Initializing } ==
     LightAudioPlayerAvailability.Ready
 
-internal fun LightAudioItem.toMediaItem(queueIndex: Int): MediaItem {
-    val uri = Uri.parse(source.uriString())
-    return MediaItem.Builder()
-        .setUri(uri)
-        .setMediaId(uri.toString())
-        .setMediaMetadata(metadata.toMedia3Metadata(queueIndex))
-        .build()
-}
+internal fun LightAudioItem.toMediaItem(): MediaItem = MediaItem.Builder()
+    .setUri(Uri.parse(source.uriString()))
+    .setMediaId(stableId())
+    .setMediaMetadata(metadata.toMedia3Metadata())
+    .build()
+
+/** This item's [LightAudioItem.id], or its location when identity is location. */
+internal fun LightAudioItem.stableId(): String = id ?: source.uriString()
 
 internal fun LightAudioSource.uriString(): String = when (this) {
     is LightAudioSource.FileSource -> Uri.fromFile(file).toString()
@@ -323,13 +424,12 @@ internal fun LightAudioSource.uriString(): String = when (this) {
     is LightAudioSource.UrlSource -> url
 }
 
-private fun LightMediaMetadata.toMedia3Metadata(queueIndex: Int): MediaMetadata {
+private fun LightMediaMetadata.toMedia3Metadata(): MediaMetadata {
     return MediaMetadata.Builder()
         .setTitle(title)
         .setArtist(artist)
         .setAlbumTitle(album)
         .setDurationMs(durationMs)
-        .setTrackNumber(queueIndex + 1)
         .build()
 }
 
@@ -339,6 +439,7 @@ internal fun skipPosition(positionMs: Long, durationMs: Long, deltaMs: Long): Lo
 
 internal data class ConnectedPlayerState(
     val currentMediaItemIndex: Int,
+    val mediaItemCount: Int,
     val positionMs: Long,
     val durationMs: Long,
     val isPlaying: Boolean,
@@ -346,6 +447,7 @@ internal data class ConnectedPlayerState(
 
 internal fun Player.snapshotState(): ConnectedPlayerState = ConnectedPlayerState(
     currentMediaItemIndex = if (mediaItemCount == 0) NO_MEDIA_ITEM else currentMediaItemIndex,
+    mediaItemCount = mediaItemCount,
     positionMs = currentPosition.coerceAtLeast(0L),
     durationMs = duration.validDuration(),
     isPlaying = isPlaying,

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudioPlayer.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudioPlayer.kt
@@ -42,11 +42,13 @@ enum class LightAudioPlayerAvailability {
  * Transient focus loss pauses and later resumes playback; duckable loss lowers
  * volume. Call [release] when the owning screen is destroyed.
  */
+@OptIn(UnstableApi::class)
 class LightAudioPlayer internal constructor(
     context: Context,
     usage: LightAudioUsage = LightAudioUsage.Music,
     internal val playback: LightAudioPlayback = LightAudioPlayback.Attached,
     caches: List<LightMediaCache> = emptyList(),
+    sourceFactory: LightMediaSourceFactory? = null,
     private val onRelease: () -> Unit = {},
 ) {
     private val scopeJob = SupervisorJob()
@@ -81,7 +83,7 @@ class LightAudioPlayer internal constructor(
     init {
         when (playback) {
             LightAudioPlayback.Attached ->
-                connectPlayer(buildSdkExoPlayer(context, usage, caches))
+                connectPlayer(buildSdkExoPlayer(context, usage, caches, sourceFactory))
             // The detached player was built by the service from staged caches.
             LightAudioPlayback.Detached -> connectDetachedPlayer(context, usage)
         }

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudioService.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudioService.kt
@@ -32,14 +32,20 @@ internal class LightAudioService : MediaSessionService() {
 
         assertSharedProcess()
 
-        player = ExoPlayer.Builder(this).build().apply {
-            setAudioAttributes(LightAudioUsage.Music.toMedia3AudioAttributes(), true)
+        // Whatever the starting handle staged, taken now because a player cannot
+        // be told where to read from once it exists. A session the system
+        // revived rather than a tool started has nothing staged, and records
+        // that, so a later handle asking for caches is refused rather than
+        // silently given a player that has none.
+        val caches = detachedSessionState.stagedCaches()
+        player = buildSdkExoPlayer(this, LightAudioUsage.Music, caches).apply {
             addListener(object : Player.Listener {
                 override fun onIsPlayingChanged(isPlaying: Boolean) {
                     refreshIdleStop()
                 }
             })
         }
+        detachedSessionState.adoptCaches(caches)
         session = MediaSession.Builder(this, player)
             .setId(packageName)
             .setCallback(SessionCallback())

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudioService.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudioService.kt
@@ -35,11 +35,7 @@ internal class LightAudioService : MediaSessionService() {
 
         assertSharedProcess()
 
-        // Whatever the starting handle staged, taken now because a player cannot
-        // be told where to read from once it exists. A session the system
-        // revived rather than a tool started has nothing staged, and records
-        // that, so a later handle asking for caches is refused rather than
-        // silently given a player that has none.
+        // Whatever the starting handle staged. Empty if the system revived the service.
         val caches = detachedSessionState.stagedCaches()
         val sourceFactory = detachedSessionState.stagedSourceFactory()
         player = buildSdkExoPlayer(this, LightAudioUsage.Music, caches, sourceFactory).apply {

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudioService.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudioService.kt
@@ -3,7 +3,9 @@ package com.thelightphone.sdk.audio
 import android.app.Application
 import android.os.Handler
 import android.os.Looper
+import androidx.annotation.OptIn
 import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.session.MediaSession
 import androidx.media3.session.MediaSessionService
@@ -20,6 +22,7 @@ import androidx.media3.session.MediaSessionService
  * stopped by itself once playback is paused and no tool holds a handle — see
  * [shouldStartIdleStop].
  */
+@OptIn(UnstableApi::class)
 internal class LightAudioService : MediaSessionService() {
 
     private lateinit var player: ExoPlayer
@@ -38,7 +41,8 @@ internal class LightAudioService : MediaSessionService() {
         // that, so a later handle asking for caches is refused rather than
         // silently given a player that has none.
         val caches = detachedSessionState.stagedCaches()
-        player = buildSdkExoPlayer(this, LightAudioUsage.Music, caches).apply {
+        val sourceFactory = detachedSessionState.stagedSourceFactory()
+        player = buildSdkExoPlayer(this, LightAudioUsage.Music, caches, sourceFactory).apply {
             addListener(object : Player.Listener {
                 override fun onIsPlayingChanged(isPlaying: Boolean) {
                     refreshIdleStop()
@@ -46,6 +50,7 @@ internal class LightAudioService : MediaSessionService() {
             })
         }
         detachedSessionState.adoptCaches(caches)
+        detachedSessionState.adoptSourceFactory(sourceFactory != null)
         session = MediaSession.Builder(this, player)
             .setId(packageName)
             .setCallback(SessionCallback())

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightMediaCache.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightMediaCache.kt
@@ -33,8 +33,8 @@ sealed interface LightCacheEviction {
     /**
      * Discards the bytes read longest ago to stay under [maxBytes].
      *
-     * This is where newly streamed bytes land, so a player with no such cache
-     * caches nothing it streams.
+     * This is where the SDK writes what it streams, so a player with no such
+     * cache caches nothing the SDK fetched.
      */
     data class LeastRecentlyUsed(val maxBytes: Long) : LightCacheEviction {
         init {
@@ -45,8 +45,10 @@ sealed interface LightCacheEviction {
     /**
      * Discards nothing, leaving the tool to decide what to delete and when.
      *
-     * Playback only ever reads such a store, so it holds what the tool put
-     * there deliberately rather than whatever was played recently.
+     * The SDK never writes here: streaming into a store that never evicts would
+     * pin every byte played, which is a decision only the tool can make. A
+     * [LightMediaSourceFactory] can write here, since a tool supplying its own
+     * pipeline is already deciding what to keep.
      */
     data object Never : LightCacheEviction
 }
@@ -54,16 +56,24 @@ sealed interface LightCacheEviction {
 /**
  * Rejects cache lists that cannot mean one thing.
  *
- * Reads consult caches in the order given, so the list is already an ordering.
- * What it must not also be is ambiguous about where bytes are written, which
- * two size-limited caches would make it.
+ * Names have to be distinct however the caches are used, since a name is a
+ * directory and two of them would be one store under two descriptions.
+ *
+ * The single-writer rule is narrower. It exists because the SDK's own read path
+ * has to pick one cache to stream into, and two size-limited caches leave that
+ * unsaid. A [hasCustomSource] tool does its own writing and can reasonably fill
+ * several stores, so the rule would only be the SDK legislating a decision it
+ * no longer makes.
  */
-internal fun validateMediaCaches(caches: List<LightMediaCache>) {
+internal fun validateMediaCaches(caches: List<LightMediaCache>, hasCustomSource: Boolean) {
     val names = caches.map(LightMediaCache::name)
     require(names.size == names.toSet().size) {
         "Each cache must have a distinct name, but got $names"
     }
-    require(caches.count { it.eviction is LightCacheEviction.LeastRecentlyUsed } <= 1) {
+    require(
+        hasCustomSource ||
+            caches.count { it.eviction is LightCacheEviction.LeastRecentlyUsed } <= 1
+    ) {
         "At most one cache may be size-limited, since that is the one written while streaming"
     }
 }

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightMediaCache.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightMediaCache.kt
@@ -1,0 +1,69 @@
+package com.thelightphone.sdk.audio
+
+/**
+ * A named on-disk store of media bytes, kept under the tool's own storage.
+ *
+ * A cache is described rather than handed over: the SDK opens the store, wires
+ * it into the player it builds, and shares one store per directory across the
+ * tool process. Two players naming the same cache read and write the same
+ * bytes, and a cache outlives every player that fills it.
+ *
+ * Caches are named so that bytes can be found again. Bytes are filed under
+ * [LightAudioItem.id], so an item whose location changes still finds what it
+ * cached — which is what makes a cache useful for audio behind expiring URLs.
+ *
+ * @property name identifies the store and its directory. Letters, digits, `-`,
+ *   and `_` only, since it names a directory
+ * @property eviction what the store does when it runs out of room
+ */
+data class LightMediaCache(
+    val name: String,
+    val eviction: LightCacheEviction,
+) {
+    init {
+        require(name.isNotBlank()) { "Cache name must not be blank" }
+        require(name.all { it.isLetterOrDigit() || it == '-' || it == '_' }) {
+            "Cache name must contain only letters, digits, '-', or '_', but was '$name'"
+        }
+    }
+}
+
+/** What a [LightMediaCache] does when it runs out of room. */
+sealed interface LightCacheEviction {
+    /**
+     * Discards the bytes read longest ago to stay under [maxBytes].
+     *
+     * This is where newly streamed bytes land, so a player with no such cache
+     * caches nothing it streams.
+     */
+    data class LeastRecentlyUsed(val maxBytes: Long) : LightCacheEviction {
+        init {
+            require(maxBytes > 0) { "Cache size must be positive, but was $maxBytes" }
+        }
+    }
+
+    /**
+     * Discards nothing, leaving the tool to decide what to delete and when.
+     *
+     * Playback only ever reads such a store, so it holds what the tool put
+     * there deliberately rather than whatever was played recently.
+     */
+    data object Never : LightCacheEviction
+}
+
+/**
+ * Rejects cache lists that cannot mean one thing.
+ *
+ * Reads consult caches in the order given, so the list is already an ordering.
+ * What it must not also be is ambiguous about where bytes are written, which
+ * two size-limited caches would make it.
+ */
+internal fun validateMediaCaches(caches: List<LightMediaCache>) {
+    val names = caches.map(LightMediaCache::name)
+    require(names.size == names.toSet().size) {
+        "Each cache must have a distinct name, but got $names"
+    }
+    require(caches.count { it.eviction is LightCacheEviction.LeastRecentlyUsed } <= 1) {
+        "At most one cache may be size-limited, since that is the one written while streaming"
+    }
+}

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightMediaCache.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightMediaCache.kt
@@ -3,17 +3,11 @@ package com.thelightphone.sdk.audio
 /**
  * A named on-disk store of media bytes, kept under the tool's own storage.
  *
- * A cache is described rather than handed over: the SDK opens the store, wires
- * it into the player it builds, and shares one store per directory across the
- * tool process. Two players naming the same cache read and write the same
- * bytes, and a cache outlives every player that fills it.
+ * The SDK opens the store, wires it into the player it builds, and shares one
+ * per directory across the process. Bytes are filed under [LightAudioItem.id],
+ * so an item whose location changes still finds what it cached.
  *
- * Caches are named so that bytes can be found again. Bytes are filed under
- * [LightAudioItem.id], so an item whose location changes still finds what it
- * cached — which is what makes a cache useful for audio behind expiring URLs.
- *
- * @property name identifies the store and its directory. Letters, digits, `-`,
- *   and `_` only, since it names a directory
+ * @property name directory name: letters, digits, `-`, and `_` only
  * @property eviction what the store does when it runs out of room
  */
 data class LightMediaCache(
@@ -33,8 +27,7 @@ sealed interface LightCacheEviction {
     /**
      * Discards the bytes read longest ago to stay under [maxBytes].
      *
-     * This is where the SDK writes what it streams, so a player with no such
-     * cache caches nothing the SDK fetched.
+     * This is where the SDK writes what it streams.
      */
     data class LeastRecentlyUsed(val maxBytes: Long) : LightCacheEviction {
         init {
@@ -43,28 +36,13 @@ sealed interface LightCacheEviction {
     }
 
     /**
-     * Discards nothing, leaving the tool to decide what to delete and when.
-     *
-     * The SDK never writes here: streaming into a store that never evicts would
-     * pin every byte played, which is a decision only the tool can make. A
-     * [LightMediaSourceFactory] can write here, since a tool supplying its own
-     * pipeline is already deciding what to keep.
+     * Discards nothing. The SDK never writes here during streaming; a
+     * [LightMediaSourceFactory] may.
      */
     data object Never : LightCacheEviction
 }
 
-/**
- * Rejects cache lists that cannot mean one thing.
- *
- * Names have to be distinct however the caches are used, since a name is a
- * directory and two of them would be one store under two descriptions.
- *
- * The single-writer rule is narrower. It exists because the SDK's own read path
- * has to pick one cache to stream into, and two size-limited caches leave that
- * unsaid. A [hasCustomSource] tool does its own writing and can reasonably fill
- * several stores, so the rule would only be the SDK legislating a decision it
- * no longer makes.
- */
+/** Distinct names always. At most one LRU unless [hasCustomSource] is writing. */
 internal fun validateMediaCaches(caches: List<LightMediaCache>, hasCustomSource: Boolean) {
     val names = caches.map(LightMediaCache::name)
     require(names.size == names.toSet().size) {

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightMediaSourceFactory.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightMediaSourceFactory.kt
@@ -8,18 +8,12 @@ import androidx.media3.exoplayer.source.MediaSource
 /**
  * Supplies the media3 `MediaSource.Factory` the SDK's player reads through.
  *
- * A [LightMediaCache] describes where bytes are kept, which is enough for audio
- * media3 can fetch itself. Audio it cannot fetch — anything that has to be
- * decrypted, unwrapped, or pulled out of a session the tool owns — cannot be
- * described as data at all, so the tool supplies the input pipeline instead.
+ * Use this for audio media3 cannot fetch itself (decrypt, a session the tool
+ * owns). It replaces the SDK's HTTP read path and cannot reach sink, focus,
+ * session, or queue.
  *
- * The SDK still owns the output half. Audio attributes, focus, the media
- * session, and the queue stay with the player the SDK builds, and a factory
- * cannot reach them: it is asked only where audio comes from.
- *
- * This runs while the player is being constructed, and in detached playback
- * that construction happens inside [LightAudioService]. The factory therefore
- * outlives the screen that installed it, so it must not capture UI state.
+ * Runs at player construction, which in detached playback is inside
+ * [LightAudioService], so the factory must not capture UI state.
  */
 @UnstableApi
 fun interface LightMediaSourceFactory {
@@ -29,16 +23,13 @@ fun interface LightMediaSourceFactory {
 /**
  * The media3 pieces the SDK will hand a [LightMediaSourceFactory].
  *
- * Tools have no `Context`, so they cannot open a cache or build a data source
- * that reads local files. Both arrive here already built, rooted in the tool's
- * own storage.
+ * Tools have no `Context`, so caches and a platform data source are already
+ * built here, rooted in the tool's own storage.
  *
- * @property caches every cache passed to `newPlayer`, opened and keyed by
- *   [LightMediaCache.name]. Shared process-wide, so a factory that writes here
- *   fills the same store playback reads from
- * @property dataSourceFactory reads `file://`, `asset://`, `content://`, and
- *   HTTP, with no caching of its own. Wrap it to add caching, or ignore it
- *   entirely when the audio does not come from any of those
+ * @property caches caches passed to `newPlayer`, opened and keyed by
+ *   [LightMediaCache.name]
+ * @property dataSourceFactory `file://`, `asset://`, `content://`, and HTTP,
+ *   with no caching. Wrap it, or ignore it when the audio comes from elsewhere
  */
 @UnstableApi
 class LightMediaEnv internal constructor(

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightMediaSourceFactory.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightMediaSourceFactory.kt
@@ -1,0 +1,47 @@
+package com.thelightphone.sdk.audio
+
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.cache.Cache
+import androidx.media3.exoplayer.source.MediaSource
+
+/**
+ * Supplies the media3 `MediaSource.Factory` the SDK's player reads through.
+ *
+ * A [LightMediaCache] describes where bytes are kept, which is enough for audio
+ * media3 can fetch itself. Audio it cannot fetch — anything that has to be
+ * decrypted, unwrapped, or pulled out of a session the tool owns — cannot be
+ * described as data at all, so the tool supplies the input pipeline instead.
+ *
+ * The SDK still owns the output half. Audio attributes, focus, the media
+ * session, and the queue stay with the player the SDK builds, and a factory
+ * cannot reach them: it is asked only where audio comes from.
+ *
+ * This runs while the player is being constructed, and in detached playback
+ * that construction happens inside [LightAudioService]. The factory therefore
+ * outlives the screen that installed it, so it must not capture UI state.
+ */
+@UnstableApi
+fun interface LightMediaSourceFactory {
+    fun create(env: LightMediaEnv): MediaSource.Factory
+}
+
+/**
+ * The media3 pieces the SDK will hand a [LightMediaSourceFactory].
+ *
+ * Tools have no `Context`, so they cannot open a cache or build a data source
+ * that reads local files. Both arrive here already built, rooted in the tool's
+ * own storage.
+ *
+ * @property caches every cache passed to `newPlayer`, opened and keyed by
+ *   [LightMediaCache.name]. Shared process-wide, so a factory that writes here
+ *   fills the same store playback reads from
+ * @property dataSourceFactory reads `file://`, `asset://`, `content://`, and
+ *   HTTP, with no caching of its own. Wrap it to add caching, or ignore it
+ *   entirely when the audio does not come from any of those
+ */
+@UnstableApi
+class LightMediaEnv internal constructor(
+    val caches: Map<String, Cache>,
+    val dataSourceFactory: DataSource.Factory,
+)

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/SdkExoPlayer.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/SdkExoPlayer.kt
@@ -22,26 +22,42 @@ import java.util.concurrent.ConcurrentHashMap
  * Builds the player the SDK owns, in the one place both playback modes reach.
  *
  * Attached players build here, and so does [LightAudioService] in `onCreate`.
- * Caches have to be settled by now: where a player reads bytes from is a
- * constructor argument, so unlike [LightAudioUsage] it cannot be applied to a
- * player that already exists.
+ * Caches and [sourceFactory] have to be settled by now: where a player reads
+ * bytes from is a constructor argument, so unlike [LightAudioUsage] it cannot
+ * be applied to a player that already exists.
+ *
+ * A [sourceFactory] replaces the SDK's own read path rather than layering onto
+ * it. The tool is saying media3 cannot fetch this audio unaided, so wrapping
+ * its answer in the SDK's HTTP pipeline would only put a fetcher it already
+ * rejected back in front of it. The caches still open, and the factory gets
+ * them, so opting out of the read path does not mean opting out of storage.
  */
 @OptIn(UnstableApi::class)
 internal fun buildSdkExoPlayer(
     context: Context,
     usage: LightAudioUsage,
     caches: List<LightMediaCache>,
+    sourceFactory: LightMediaSourceFactory? = null,
 ): ExoPlayer {
     val builder = ExoPlayer.Builder(context)
-    if (caches.isNotEmpty()) {
-        builder.setMediaSourceFactory(
-            DefaultMediaSourceFactory(cachingDataSourceFactory(context, caches))
+    val opened = caches.associate { it.name to mediaCacheStore.open(context, it) }
+    when {
+        sourceFactory != null -> builder.setMediaSourceFactory(
+            sourceFactory.create(LightMediaEnv(opened, platformDataSourceFactory(context)))
+        )
+        caches.isNotEmpty() -> builder.setMediaSourceFactory(
+            DefaultMediaSourceFactory(cachingDataSourceFactory(context, caches, opened))
         )
     }
     return builder.build().apply {
         setAudioAttributes(usage.toMedia3AudioAttributes(), true)
     }
 }
+
+/** Everything the platform can read without help, and nothing cached. */
+@OptIn(UnstableApi::class)
+private fun platformDataSourceFactory(context: Context): DataSource.Factory =
+    DefaultDataSource.Factory(context, DefaultHttpDataSource.Factory())
 
 /**
  * Puts the tool's caches between the network and the player, consulted in the
@@ -56,11 +72,12 @@ internal fun buildSdkExoPlayer(
 private fun cachingDataSourceFactory(
     context: Context,
     caches: List<LightMediaCache>,
+    opened: Map<String, Cache>,
 ): DataSource.Factory {
     var network: DataSource.Factory = DefaultHttpDataSource.Factory()
     for (cache in caches.asReversed()) {
         val factory = CacheDataSource.Factory()
-            .setCache(mediaCacheStore.open(context, cache))
+            .setCache(requireNotNull(opened[cache.name]))
             .setUpstreamDataSourceFactory(network)
             // A cache that cannot serve a read should cost latency, not playback.
             .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/SdkExoPlayer.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/SdkExoPlayer.kt
@@ -1,0 +1,123 @@
+package com.thelightphone.sdk.audio
+
+import android.content.Context
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.database.DatabaseProvider
+import androidx.media3.database.StandaloneDatabaseProvider
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.DefaultHttpDataSource
+import androidx.media3.datasource.cache.Cache
+import androidx.media3.datasource.cache.CacheDataSource
+import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
+import androidx.media3.datasource.cache.NoOpCacheEvictor
+import androidx.media3.datasource.cache.SimpleCache
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import java.io.File
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * Builds the player the SDK owns, in the one place both playback modes reach.
+ *
+ * Attached players build here, and so does [LightAudioService] in `onCreate`.
+ * Caches have to be settled by now: where a player reads bytes from is a
+ * constructor argument, so unlike [LightAudioUsage] it cannot be applied to a
+ * player that already exists.
+ */
+@OptIn(UnstableApi::class)
+internal fun buildSdkExoPlayer(
+    context: Context,
+    usage: LightAudioUsage,
+    caches: List<LightMediaCache>,
+): ExoPlayer {
+    val builder = ExoPlayer.Builder(context)
+    if (caches.isNotEmpty()) {
+        builder.setMediaSourceFactory(
+            DefaultMediaSourceFactory(cachingDataSourceFactory(context, caches))
+        )
+    }
+    return builder.build().apply {
+        setAudioAttributes(usage.toMedia3AudioAttributes(), true)
+    }
+}
+
+/**
+ * Puts the tool's caches between the network and the player, consulted in the
+ * order the tool listed them and only then falling through to the network.
+ *
+ * The caches wrap HTTP alone, and [DefaultDataSource] wraps them, because it
+ * serves `file://`, `asset://`, and `content://` itself and delegates only what
+ * it cannot serve. Bytes already on the device therefore never get copied into
+ * a cache to sit beside themselves.
+ */
+@OptIn(UnstableApi::class)
+private fun cachingDataSourceFactory(
+    context: Context,
+    caches: List<LightMediaCache>,
+): DataSource.Factory {
+    var network: DataSource.Factory = DefaultHttpDataSource.Factory()
+    for (cache in caches.asReversed()) {
+        val factory = CacheDataSource.Factory()
+            .setCache(mediaCacheStore.open(context, cache))
+            .setUpstreamDataSourceFactory(network)
+            // A cache that cannot serve a read should cost latency, not playback.
+            .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
+        if (cache.eviction is LightCacheEviction.Never) {
+            // Null sink: the tool fills this one deliberately, so streaming
+            // must not quietly grow a store that never evicts.
+            factory.setCacheWriteDataSinkFactory(null)
+        }
+        network = factory
+    }
+    return DefaultDataSource.Factory(context, network)
+}
+
+/**
+ * The caches this tool process has open, one per directory.
+ *
+ * media3 permits a single [SimpleCache] per directory per process and throws on
+ * the second, so opening must be atomic rather than merely usually-fine: an
+ * attached player and [LightAudioService] can reach for the same cache at once.
+ */
+@OptIn(UnstableApi::class)
+internal class MediaCacheStore {
+    private val cachesByPath = ConcurrentHashMap<String, Cache>()
+    private val databaseProviders = ConcurrentHashMap<Context, DatabaseProvider>()
+
+    fun open(context: Context, spec: LightMediaCache): Cache {
+        val appContext = context.applicationContext
+        val directory = spec.directoryIn(appContext)
+        return cachesByPath.computeIfAbsent(directory.canonicalPath) {
+            SimpleCache(directory, spec.eviction.toEvictor(), databaseProvider(appContext))
+        }
+    }
+
+    private fun databaseProvider(appContext: Context): DatabaseProvider =
+        databaseProviders.computeIfAbsent(appContext) { StandaloneDatabaseProvider(it) }
+}
+
+internal val mediaCacheStore = MediaCacheStore()
+
+/**
+ * A size-limited cache lives in cache storage, which the platform may reclaim
+ * under pressure — the same bargain the tool already made by bounding it. A
+ * cache that never evicts lives in files storage, where nothing but the tool
+ * removes it.
+ */
+private fun LightMediaCache.directoryIn(context: Context): File {
+    val root = when (eviction) {
+        is LightCacheEviction.LeastRecentlyUsed -> context.cacheDir
+        LightCacheEviction.Never -> context.filesDir
+    }
+    return File(File(root, CACHE_ROOT_DIR), name).apply { mkdirs() }
+}
+
+@OptIn(UnstableApi::class)
+private fun LightCacheEviction.toEvictor() = when (this) {
+    is LightCacheEviction.LeastRecentlyUsed -> LeastRecentlyUsedCacheEvictor(maxBytes)
+    LightCacheEviction.Never -> NoOpCacheEvictor()
+}
+
+private const val CACHE_ROOT_DIR = "light-media-cache"

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/SdkExoPlayer.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/SdkExoPlayer.kt
@@ -21,16 +21,8 @@ import java.util.concurrent.ConcurrentHashMap
 /**
  * Builds the player the SDK owns, in the one place both playback modes reach.
  *
- * Attached players build here, and so does [LightAudioService] in `onCreate`.
- * Caches and [sourceFactory] have to be settled by now: where a player reads
- * bytes from is a constructor argument, so unlike [LightAudioUsage] it cannot
- * be applied to a player that already exists.
- *
- * A [sourceFactory] replaces the SDK's own read path rather than layering onto
- * it. The tool is saying media3 cannot fetch this audio unaided, so wrapping
- * its answer in the SDK's HTTP pipeline would only put a fetcher it already
- * rejected back in front of it. The caches still open, and the factory gets
- * them, so opting out of the read path does not mean opting out of storage.
+ * A [sourceFactory] replaces the SDK HTTP path. Requested caches still open
+ * and are handed to the factory.
  */
 @OptIn(UnstableApi::class)
 internal fun buildSdkExoPlayer(
@@ -60,13 +52,8 @@ private fun platformDataSourceFactory(context: Context): DataSource.Factory =
     DefaultDataSource.Factory(context, DefaultHttpDataSource.Factory())
 
 /**
- * Puts the tool's caches between the network and the player, consulted in the
- * order the tool listed them and only then falling through to the network.
- *
- * The caches wrap HTTP alone, and [DefaultDataSource] wraps them, because it
- * serves `file://`, `asset://`, and `content://` itself and delegates only what
- * it cannot serve. Bytes already on the device therefore never get copied into
- * a cache to sit beside themselves.
+ * Caches wrap HTTP only; [DefaultDataSource] wraps them so local files are
+ * not copied into the cache.
  */
 @OptIn(UnstableApi::class)
 private fun cachingDataSourceFactory(
@@ -79,11 +66,8 @@ private fun cachingDataSourceFactory(
         val factory = CacheDataSource.Factory()
             .setCache(requireNotNull(opened[cache.name]))
             .setUpstreamDataSourceFactory(network)
-            // A cache that cannot serve a read should cost latency, not playback.
             .setFlags(CacheDataSource.FLAG_IGNORE_CACHE_ON_ERROR)
         if (cache.eviction is LightCacheEviction.Never) {
-            // Null sink: the tool fills this one deliberately, so streaming
-            // must not quietly grow a store that never evicts.
             factory.setCacheWriteDataSinkFactory(null)
         }
         network = factory
@@ -92,10 +76,7 @@ private fun cachingDataSourceFactory(
 }
 
 /**
- * The caches this tool process has open, one per directory.
- *
- * media3 permits a single [SimpleCache] per directory per process and throws on
- * the second, so opening must be atomic rather than merely usually-fine: an
+ * One [SimpleCache] per directory per process. Opening is atomic because an
  * attached player and [LightAudioService] can reach for the same cache at once.
  */
 @OptIn(UnstableApi::class)
@@ -117,12 +98,7 @@ internal class MediaCacheStore {
 
 internal val mediaCacheStore = MediaCacheStore()
 
-/**
- * A size-limited cache lives in cache storage, which the platform may reclaim
- * under pressure — the same bargain the tool already made by bounding it. A
- * cache that never evicts lives in files storage, where nothing but the tool
- * removes it.
- */
+/** LRU caches live in `cacheDir`; never-evict caches live in `filesDir`. */
 private fun LightMediaCache.directoryIn(context: Context): File {
     val root = when (eviction) {
         is LightCacheEviction.LeastRecentlyUsed -> context.cacheDir

--- a/sdk/client/src/test/kotlin/com/thelightphone/sdk/audio/LightAudioPlayerTest.kt
+++ b/sdk/client/src/test/kotlin/com/thelightphone/sdk/audio/LightAudioPlayerTest.kt
@@ -68,6 +68,7 @@ class LightAudioPlayerTest {
         assertEquals(
             ConnectedPlayerState(
                 currentMediaItemIndex = 1,
+                mediaItemCount = 3,
                 positionMs = 12_345L,
                 durationMs = 60_000L,
                 isPlaying = true,
@@ -94,7 +95,23 @@ class LightAudioPlayerTest {
 
         val state = freshPlayer.snapshotState()
         assertEquals(NO_MEDIA_ITEM, state.currentMediaItemIndex)
+        assertEquals(0, state.mediaItemCount)
         assertEquals(0L, state.durationMs)
+    }
+
+    @Test
+    fun itemIdentityFallsBackToLocationAndSurvivesRelocation() {
+        val located = LightAudioItem(
+            source = LightAudioSource.UrlSource("https://cdn.example.com/a.mp3?token=first"),
+            metadata = LightMediaMetadata("Track"),
+        )
+        assertEquals("https://cdn.example.com/a.mp3?token=first", located.stableId())
+
+        val identified = located.copy(id = "track-1")
+        val reResolved = identified.copy(
+            source = LightAudioSource.UrlSource("https://cdn.example.com/a.mp3?token=second"),
+        )
+        assertEquals(identified.stableId(), reResolved.stableId())
     }
 
     @Test

--- a/sdk/client/src/test/kotlin/com/thelightphone/sdk/audio/LightMediaCacheTest.kt
+++ b/sdk/client/src/test/kotlin/com/thelightphone/sdk/audio/LightMediaCacheTest.kt
@@ -60,10 +60,6 @@ class LightMediaCacheTest {
         }
     }
 
-    /**
-     * The single-writer rule speaks for the SDK's read path. A tool supplying
-     * its own decides for itself which stores it fills.
-     */
     @Test
     fun aCustomSourceMayFillSeveralSizeLimitedCaches() {
         validateMediaCaches(
@@ -91,10 +87,6 @@ class DetachedSessionCacheTest {
         )
     }
 
-    /**
-     * The service reads staged caches in `onCreate`, which is why they are left
-     * behind before a controller is ever built.
-     */
     @Test
     fun stagedCachesSurviveUntilTheServiceBuildsItsPlayer() {
         val state = DetachedSessionState()
@@ -139,10 +131,6 @@ class DetachedSessionCacheTest {
 }
 
 class DetachedSourceFactoryTest {
-    /**
-     * Two factories cannot be compared, so a live session accepts none rather
-     * than pretending to check the one it is offered.
-     */
     @Test
     fun aLiveSessionAcceptsAReconnectOnlyWithoutAFactory() {
         assertTrue(isDetachedSourceFactoryCompatible(null, someSourceFactory))
@@ -162,7 +150,6 @@ class DetachedSourceFactoryTest {
         assertNull(state.activeSourceFactoryPresence())
     }
 
-    /** The lambda is dropped once used; only the fact of it is worth keeping. */
     @Test
     fun adoptingRecordsPresenceAndReleasesTheFactory() {
         val state = DetachedSessionState()

--- a/sdk/client/src/test/kotlin/com/thelightphone/sdk/audio/LightMediaCacheTest.kt
+++ b/sdk/client/src/test/kotlin/com/thelightphone/sdk/audio/LightMediaCacheTest.kt
@@ -1,0 +1,111 @@
+package com.thelightphone.sdk.audio
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+private val streamCache = LightMediaCache(
+    name = "stream",
+    eviction = LightCacheEviction.LeastRecentlyUsed(maxBytes = 256L * 1024 * 1024),
+)
+private val savedCache = LightMediaCache(name = "saved", eviction = LightCacheEviction.Never)
+
+class LightMediaCacheTest {
+    @Test
+    fun cacheNameHasToBeUsableAsADirectoryName() {
+        assertFailsWith<IllegalArgumentException> {
+            LightMediaCache(" ", LightCacheEviction.Never)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LightMediaCache("../escape", LightCacheEviction.Never)
+        }
+        assertFailsWith<IllegalArgumentException> {
+            LightMediaCache("nested/name", LightCacheEviction.Never)
+        }
+        assertEquals("tidal_stream-1", LightMediaCache("tidal_stream-1", LightCacheEviction.Never).name)
+    }
+
+    @Test
+    fun sizeLimitedCacheNeedsRoomToWorkWith() {
+        assertFailsWith<IllegalArgumentException> { LightCacheEviction.LeastRecentlyUsed(0) }
+        assertFailsWith<IllegalArgumentException> { LightCacheEviction.LeastRecentlyUsed(-1) }
+    }
+
+    @Test
+    fun readThroughOrderAcceptsOneWritableCacheAheadOfSavedOnes() {
+        validateMediaCaches(emptyList())
+        validateMediaCaches(listOf(streamCache, savedCache))
+        validateMediaCaches(listOf(savedCache))
+    }
+
+    @Test
+    fun cachesCannotShareANameOrBothClaimTheStreamedBytes() {
+        assertFailsWith<IllegalArgumentException> {
+            validateMediaCaches(listOf(savedCache, savedCache))
+        }
+        assertFailsWith<IllegalArgumentException> {
+            validateMediaCaches(listOf(streamCache, streamCache.copy(name = "other")))
+        }
+    }
+}
+
+class DetachedSessionCacheTest {
+    @Test
+    fun cacheCompatibilityAcceptsFreshSessionsAndMatchingRequestsOnly() {
+        assertTrue(isDetachedCacheCompatible(activeCaches = null, listOf(streamCache)))
+        assertTrue(isDetachedCacheCompatible(listOf(streamCache), listOf(streamCache)))
+        assertFalse(isDetachedCacheCompatible(emptyList(), listOf(streamCache)))
+        assertFalse(
+            isDetachedCacheCompatible(listOf(streamCache, savedCache), listOf(savedCache, streamCache)),
+        )
+    }
+
+    /**
+     * The service reads staged caches in `onCreate`, which is why they are left
+     * behind before a controller is ever built.
+     */
+    @Test
+    fun stagedCachesSurviveUntilTheServiceBuildsItsPlayer() {
+        val state = DetachedSessionState()
+
+        state.stageCaches(listOf(streamCache))
+
+        assertEquals(listOf(streamCache), state.stagedCaches())
+        assertNull(state.activeCaches())
+    }
+
+    @Test
+    fun adoptingCachesPublishesThemAndConsumesTheStaging() {
+        val state = DetachedSessionState()
+        state.stageCaches(listOf(streamCache))
+
+        state.adoptCaches(state.stagedCaches())
+
+        assertEquals(listOf(streamCache), state.activeCaches())
+        assertEquals(emptyList(), state.stagedCaches())
+    }
+
+    @Test
+    fun aRevivedSessionRecordsThatItWasBuiltWithoutCaches() {
+        val state = DetachedSessionState()
+
+        state.adoptCaches(state.stagedCaches())
+
+        assertEquals(emptyList(), state.activeCaches())
+        assertFalse(isDetachedCacheCompatible(state.activeCaches(), listOf(streamCache)))
+    }
+
+    @Test
+    fun clearingTheSessionLetsTheNextHandleChooseCachesAgain() {
+        val state = DetachedSessionState()
+        state.adoptCaches(listOf(streamCache))
+
+        state.clearSession()
+
+        assertNull(state.activeCaches())
+        assertTrue(isDetachedCacheCompatible(state.activeCaches(), listOf(savedCache)))
+    }
+}

--- a/sdk/client/src/test/kotlin/com/thelightphone/sdk/audio/LightMediaCacheTest.kt
+++ b/sdk/client/src/test/kotlin/com/thelightphone/sdk/audio/LightMediaCacheTest.kt
@@ -1,5 +1,7 @@
 package com.thelightphone.sdk.audio
 
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
@@ -12,6 +14,10 @@ private val streamCache = LightMediaCache(
     eviction = LightCacheEviction.LeastRecentlyUsed(maxBytes = 256L * 1024 * 1024),
 )
 private val savedCache = LightMediaCache(name = "saved", eviction = LightCacheEviction.Never)
+
+/** Never invoked: these tests only care whether a factory was supplied. */
+@OptIn(UnstableApi::class)
+private val someSourceFactory = LightMediaSourceFactory { error("not built in this test") }
 
 class LightMediaCacheTest {
     @Test
@@ -36,18 +42,40 @@ class LightMediaCacheTest {
 
     @Test
     fun readThroughOrderAcceptsOneWritableCacheAheadOfSavedOnes() {
-        validateMediaCaches(emptyList())
-        validateMediaCaches(listOf(streamCache, savedCache))
-        validateMediaCaches(listOf(savedCache))
+        validateMediaCaches(emptyList(), hasCustomSource = false)
+        validateMediaCaches(listOf(streamCache, savedCache), hasCustomSource = false)
+        validateMediaCaches(listOf(savedCache), hasCustomSource = false)
     }
 
     @Test
     fun cachesCannotShareANameOrBothClaimTheStreamedBytes() {
         assertFailsWith<IllegalArgumentException> {
-            validateMediaCaches(listOf(savedCache, savedCache))
+            validateMediaCaches(listOf(savedCache, savedCache), hasCustomSource = false)
         }
         assertFailsWith<IllegalArgumentException> {
-            validateMediaCaches(listOf(streamCache, streamCache.copy(name = "other")))
+            validateMediaCaches(
+                listOf(streamCache, streamCache.copy(name = "other")),
+                hasCustomSource = false,
+            )
+        }
+    }
+
+    /**
+     * The single-writer rule speaks for the SDK's read path. A tool supplying
+     * its own decides for itself which stores it fills.
+     */
+    @Test
+    fun aCustomSourceMayFillSeveralSizeLimitedCaches() {
+        validateMediaCaches(
+            listOf(streamCache, streamCache.copy(name = "other")),
+            hasCustomSource = true,
+        )
+    }
+
+    @Test
+    fun namesStayDistinctEvenWithACustomSource() {
+        assertFailsWith<IllegalArgumentException> {
+            validateMediaCaches(listOf(savedCache, savedCache), hasCustomSource = true)
         }
     }
 }
@@ -107,5 +135,63 @@ class DetachedSessionCacheTest {
 
         assertNull(state.activeCaches())
         assertTrue(isDetachedCacheCompatible(state.activeCaches(), listOf(savedCache)))
+    }
+}
+
+class DetachedSourceFactoryTest {
+    /**
+     * Two factories cannot be compared, so a live session accepts none rather
+     * than pretending to check the one it is offered.
+     */
+    @Test
+    fun aLiveSessionAcceptsAReconnectOnlyWithoutAFactory() {
+        assertTrue(isDetachedSourceFactoryCompatible(null, someSourceFactory))
+        assertTrue(isDetachedSourceFactoryCompatible(true, null))
+        assertTrue(isDetachedSourceFactoryCompatible(false, null))
+        assertFalse(isDetachedSourceFactoryCompatible(true, someSourceFactory))
+        assertFalse(isDetachedSourceFactoryCompatible(false, someSourceFactory))
+    }
+
+    @Test
+    fun stagedFactorySurvivesUntilTheServiceBuildsItsPlayer() {
+        val state = DetachedSessionState()
+
+        state.stageSourceFactory(someSourceFactory)
+
+        assertEquals(someSourceFactory, state.stagedSourceFactory())
+        assertNull(state.activeSourceFactoryPresence())
+    }
+
+    /** The lambda is dropped once used; only the fact of it is worth keeping. */
+    @Test
+    fun adoptingRecordsPresenceAndReleasesTheFactory() {
+        val state = DetachedSessionState()
+        state.stageSourceFactory(someSourceFactory)
+
+        state.adoptSourceFactory(state.stagedSourceFactory() != null)
+
+        assertEquals(true, state.activeSourceFactoryPresence())
+        assertNull(state.stagedSourceFactory())
+    }
+
+    @Test
+    fun aRevivedSessionRecordsThatItWasBuiltWithoutAFactory() {
+        val state = DetachedSessionState()
+
+        state.adoptSourceFactory(state.stagedSourceFactory() != null)
+
+        assertEquals(false, state.activeSourceFactoryPresence())
+        assertFalse(isDetachedSourceFactoryCompatible(state.activeSourceFactoryPresence(), someSourceFactory))
+    }
+
+    @Test
+    fun clearingTheSessionLetsTheNextHandleBringAFactoryAgain() {
+        val state = DetachedSessionState()
+        state.adoptSourceFactory(true)
+
+        state.clearSession()
+
+        assertNull(state.activeSourceFactoryPresence())
+        assertTrue(isDetachedSourceFactoryCompatible(state.activeSourceFactoryPresence(), someSourceFactory))
     }
 }


### PR DESCRIPTION
Okie-dokie!

First draft of some more advanced audio capabilities. I can edit the description later as needed before merge.

So as it turns out, I forgot a crucial detail in #119 . The SDK sandbox blocks most stuff regarding Context. So a straight-up handoff isn't really feasible. Below is what I think will work pretty well, and it still honors the split. 

SDK's default audio behavior and simple building of LightAudioPlayer instances is unchanged.

SDK will allow more advanced specs to be given when building an ExoPlayer instance via the _configure_ argument. SDK will also allow tools to change aspects of the media3 pipeline live--queueing, etc. Which is good, because streaming requires a lot of small changes to be made as cell service comes and goes, as the user queues up tracks, etc.

SDK will also enforce one LightMediaEnv per tool & one SimpleCache object per directory.