### PR TITLE
Add optional initial capitalization to text input

### DIFF
--- a/examples/ui-demo/src/main/kotlin/com/thelightphone/uidemo/UiDemoTextInputEditorScreen.kt
+++ b/examples/ui-demo/src/main/kotlin/com/thelightphone/uidemo/UiDemoTextInputEditorScreen.kt
@@ -17,6 +17,7 @@ import com.thelightphone.sdk.ui.LightThemeTokens
 data class EditorRequest(
     val title: String,
     val initialValue: String,
+    val initialCaps: Boolean = false,
 )
 
 class UiDemoTextInputEditorScreen(
@@ -37,6 +38,7 @@ class UiDemoTextInputEditorScreen(
                 onSubmit = { result -> goBack(result.toString()) },
                 onBack = { goBack(null) },
                 modifier = Modifier.background(LightThemeTokens.colors.background),
+                initialCaps = editorRequest.initialCaps,
             )
         }
     }

--- a/examples/ui-demo/src/main/kotlin/com/thelightphone/uidemo/UiDemoTextInputScreen.kt
+++ b/examples/ui-demo/src/main/kotlin/com/thelightphone/uidemo/UiDemoTextInputScreen.kt
@@ -68,7 +68,11 @@ class UiDemoTextInputScreen(sealedActivity: SealedLightActivity) :
                     value = nameValue,
                     placeholder = "Your name",
                     onClick = {
-                        val editorRequest = EditorRequest(title = "Name", initialValue = nameValue)
+                        val editorRequest = EditorRequest(
+                            title = "Name",
+                            initialValue = nameValue,
+                            initialCaps = nameValue.isBlank(),
+                        )
                         navigateTo(
                             screenFactory = { UiDemoTextInputEditorScreen(it, editorRequest) },
                             resultCallback = { viewModel.setName(it) }

--- a/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightTextInputEditor.kt
+++ b/sdk/ui/src/main/kotlin/com/thelightphone/sdk/ui/LightTextInputEditor.kt
@@ -55,6 +55,7 @@ fun LightTextInputEditor(
     submitIcon: LightIconConfiguration? = null,
     showBackButton: Boolean = true,
     singleLine: Boolean = false,
+    initialCaps: Boolean = false,
     editorKey: Any = remember { Any() },
 ) {
     val currentOnSubmit by rememberUpdatedState(onSubmit)
@@ -74,7 +75,7 @@ fun LightTextInputEditor(
 
     val keyboardViewModel: Lp3KeyboardViewModel<*> = viewModel<EnQwertyLp3KeyboardViewModel<*>>(
         key = "LightTextInputEditor-$editorKey",
-        factory = factory(keyboardCallback, keyboardOptionsFlow),
+        factory = factory(keyboardCallback, keyboardOptionsFlow, initialCaps),
     )
 
     LightTextInputEditor(
@@ -215,7 +216,8 @@ fun LightTextInputEditor(
 
 private fun factory(
     callback: Lp3RepeatableKeyboardCallback,
-    keyboardOptionsFlow: StateFlow<KeyboardOptions>
+    keyboardOptionsFlow: StateFlow<KeyboardOptions>,
+    initialCaps: Boolean,
 ): ViewModelProvider.Factory =
     object : ViewModelProvider.Factory {
         @Suppress("UNCHECKED_CAST")
@@ -227,7 +229,9 @@ private fun factory(
                     val showCloseButton = !it.isRootLayout
                     LayoutOptions(showCloseButton)
                 },
-            ) as T
+            ).apply {
+                if (initialCaps) setCapsMode(true)
+            } as T
         }
 
     }


### PR DESCRIPTION
For name-like fields, allow a field to have an initial capital letter (like Light OS does for contact saving).

- adds an opt-in initialCaps parameter
- existing behavior remains the default
- updates the UI demo name field to demonstrate it
- ./gradlew check passes
- closes #137
