### PR TITLE
Allow BouncyCastle on the dependency allow list

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ room = "2.7.0"
 work = "2.10.0"
 media3 = "1.10.1"
 kotlinxDatetime = "0.8.0"
+bouncycastle = "1.85"
 
 [libraries]
 unifiedpush-connector = { module = "org.unifiedpush.android:connector", version.ref = "connector" }
@@ -43,6 +44,7 @@ ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "kto
 ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
 light-keyboard = { module = "com.github.lightphone:light-keyboard", version = "v0.0.16"}
+bouncycastle-provider = { module = "org.bouncycastle:bcprov-jdk18on", version.ref = "bouncycastle" }
 androidx-camera-core = { module = "androidx.camera:camera-core", version.ref = "camerax" }
 androidx-camera-camera2 = { module = "androidx.camera:camera-camera2", version.ref = "camerax" }
 androidx-camera-lifecycle = { module = "androidx.camera:camera-lifecycle", version.ref = "camerax" }

--- a/plugin/src/main/kotlin/com/thelightphone/plugin/LightSdkPlugin.kt
+++ b/plugin/src/main/kotlin/com/thelightphone/plugin/LightSdkPlugin.kt
@@ -37,6 +37,7 @@ class LightSdkPlugin : Plugin<Project> {
             "androidx.startup",
             "androidx.media3",
             "io.github.david-allison:anki-android-backend",
+            "org.bouncycastle:bcprov-jdk18on",
         )
 
         val ALLOWED_PLUGINS = setOf(


### PR DESCRIPTION
Adds org.bouncycastle:bcprov-jdk18on (pure Java, no NDK/JNI) to the plugin's dependency allow-list, pinned to 1.85.

Closes #149. Confirmed OK by @dupontgu in #149 and discussion #139.