### PR TITLE
Add Cozy Sleep example app

### DIFF
--- a/examples/cozy-sleep-trainer/build.gradle.kts
+++ b/examples/cozy-sleep-trainer/build.gradle.kts
@@ -1,0 +1,60 @@
+plugins {
+    alias(libs.plugins.android.application)
+    alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.kotlin.compose)
+    alias(libs.plugins.kotlin.serialization)
+    alias(libs.plugins.ksp)
+    alias(libs.plugins.light.sdk)
+}
+
+android {
+    compileSdk = rootProject.ext["compileSdk"] as Int
+
+    defaultConfig {
+        minSdk = rootProject.ext["minSdk"] as Int
+        targetSdk = rootProject.ext["targetSdk"] as Int
+
+        manifestPlaceholders["sdkVersion"] = property("sdkVersion") as String
+    }
+
+    signingConfigs {
+        create("lightsdkDev") {
+            storeFile = file("../../sdk/keys/lightsdk-dev.jks")
+            storePassword = "android"
+            keyAlias = "lightsdk-dev"
+            keyPassword = "android"
+            enableV3Signing = true
+            enableV4Signing = true
+        }
+    }
+
+    buildTypes {
+        debug {
+            signingConfig = signingConfigs.getByName("lightsdkDev")
+        }
+        release {
+            signingConfig = signingConfigs.getByName("lightsdkDev")
+        }
+    }
+
+    lint {
+        warningsAsErrors = false
+        error += "RestrictedApi"
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.toVersion(rootProject.ext["jvmTarget"] as String)
+        targetCompatibility = JavaVersion.toVersion(rootProject.ext["jvmTarget"] as String)
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.fromTarget(rootProject.ext["jvmTarget"] as String))
+    }
+}
+
+dependencies {
+    implementation(project(":sdk:client"))
+    testImplementation(libs.kotlin.test)
+}

--- a/examples/cozy-sleep-trainer/lighttool.toml
+++ b/examples/cozy-sleep-trainer/lighttool.toml
@@ -1,0 +1,7 @@
+[tool]
+id = "com.thelightphone.sleeptrainer"
+label = "Cozy Sleep Trainer"
+versionCode = 1
+versionName = "1.0"
+permissions = ["android.permission.VIBRATE"]
+serverPackage = "com.lightos"

--- a/examples/cozy-sleep-trainer/src/main/kotlin/com/thelightphone/sleeptrainer/Learning.kt
+++ b/examples/cozy-sleep-trainer/src/main/kotlin/com/thelightphone/sleeptrainer/Learning.kt
@@ -1,0 +1,88 @@
+package com.thelightphone.sleeptrainer
+
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import kotlinx.coroutines.flow.first
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+
+// ----- MODELS ----- //
+
+@Serializable
+data class SessionData(
+    val totalTimeSeconds: Int,
+    val date: String,
+    val intervalsCompleted: Int = 0
+)
+
+// ----- REPOSITORY ----- // [Handles saving/loading history data]
+
+object HistoryRepository {
+    private val HISTORY_KEY = stringPreferencesKey("history")
+
+    suspend fun loadHistory(dataStore: DataStore<Preferences>): List<SessionData> {
+        val json = dataStore.data.first()[HISTORY_KEY] ?: "[]"
+        return try {
+            Json.decodeFromString<List<SessionData>>(json)
+        } catch (_: Exception) {
+            emptyList()
+        }
+    }
+
+    suspend fun saveSession(
+        dataStore: DataStore<Preferences>,
+        totalSeconds: Int,
+        intervalsCompleted: Int
+    ): List<SessionData> {
+        // Don't save very short sessions
+        if (totalSeconds < 5) return loadHistory(dataStore)
+
+        val date = SimpleDateFormat("MMM dd", Locale.US).format(Date())
+        val currentHistory = loadHistory(dataStore).toMutableList()
+
+        val newSession = SessionData(
+            totalTimeSeconds = totalSeconds,
+            date = date,
+            intervalsCompleted = intervalsCompleted
+        )
+
+        currentHistory.add(0, newSession)
+        val updatedHistory = currentHistory.take(10)
+        val json = Json.encodeToString(updatedHistory)
+
+        dataStore.edit { prefs ->
+            prefs[HISTORY_KEY] = json
+        }
+        return updatedHistory
+    }
+}
+
+// ----- SCHEDULE ----- // [The "rules" for the training]
+
+object FerberSchedule {
+    private val intervals = listOf(2, 5, 10, 15)
+
+    /** 
+     * Returns the interval length in minutes.
+     * If the index goes beyond our list, we stay at the final 15-minute interval.
+     */
+    fun getIntervalMinutes(index: Int): Int {
+        return if (index < intervals.size) {
+            intervals[index]
+        } else {
+            15 // This is the "infinite 15-minute logic"
+        }
+    }
+
+    fun formatTime(seconds: Int): String {
+        val m = seconds / 60
+        val s = seconds % 60
+        return String.format(Locale.US, "%02d:%02d", m, s)
+    }
+}

--- a/examples/cozy-sleep-trainer/src/main/kotlin/com/thelightphone/sleeptrainer/SleepTrainerHistoryScreen.kt
+++ b/examples/cozy-sleep-trainer/src/main/kotlin/com/thelightphone/sleeptrainer/SleepTrainerHistoryScreen.kt
@@ -1,0 +1,104 @@
+package com.thelightphone.sleeptrainer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.thelightphone.sdk.SealedLightActivity
+import com.thelightphone.sdk.SimpleLightScreen
+import com.thelightphone.sdk.ui.*
+
+class SleepTrainerHistoryScreen(sealedActivity: SealedLightActivity) :
+    SimpleLightScreen<Unit>(sealedActivity) {
+
+    @Composable
+    override fun Content() {
+        val themeColors by LightThemeController.colors.collectAsState()
+        var history by remember { mutableStateOf<List<SessionData>>(emptyList()) }
+
+        LaunchedEffect(Unit) {
+            history = HistoryRepository.loadHistory(lightContext.dataStore)
+        }
+
+        SleepTrainerHistoryContent(
+            history = history,
+            onBack = { goBack() }
+        )
+    }
+}
+
+@Composable
+fun SleepTrainerHistoryContent(
+    history: List<SessionData>,
+    onBack: () -> Unit
+) {
+    val themeColors by LightThemeController.colors.collectAsState()
+    LightTheme(colors = themeColors) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(LightThemeTokens.colors.background)
+        ) {
+            LightTopBar(
+                leftButton = LightBarButton.LightIcon(
+                    icon = LightIcons.BACK,
+                    onClick = { onBack() }
+                ),
+                center = LightTopBarCenter.Text("History")
+            )
+
+            if (history.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    LightText(
+                        text = "No sessions yet",
+                        variant = LightTextVariant.Detail
+                    )
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(1f.gridUnitsAsDp())
+                ) {
+                    items(history) { session ->
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = 0.5f.gridUnitsAsDp())
+                        ) {
+                            LightText(
+                                text = session.date,
+                                variant = LightTextVariant.Detail,
+                                lighten = true
+                            )
+                            LightText(
+                                text = "${session.totalTimeSeconds / 60} min • ${session.intervalsCompleted} intervals",
+                                variant = LightTextVariant.Copy
+                            )
+                            Spacer(modifier = Modifier.height(1f.gridUnitsAsDp()))
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(widthDp = 1080 / 3, heightDp = 1240 / 3, showBackground = true)
+@Composable
+fun SleepTrainerHistoryPreview() {
+    SleepTrainerHistoryContent(
+        history = listOf(
+            SessionData(300, "Jul 29", 3),
+            SessionData(600, "Jul 29", 5),
+            SessionData(120, "Jul 28", 1)
+        ),
+        onBack = {}
+    )
+}

--- a/examples/cozy-sleep-trainer/src/main/kotlin/com/thelightphone/sleeptrainer/SleepTrainerHomeScreen.kt
+++ b/examples/cozy-sleep-trainer/src/main/kotlin/com/thelightphone/sleeptrainer/SleepTrainerHomeScreen.kt
@@ -1,0 +1,243 @@
+// "This file belongs in my Sleep Training App."
+package com.thelightphone.sleeptrainer
+
+// ----- IMPORTS ----- // [Brings in resources for the app.]
+    // COMPOSE [Builds the screen] //
+    import androidx.compose.foundation.background
+    import androidx.compose.foundation.layout.*
+    import androidx.compose.runtime.*
+    import androidx.compose.ui.Alignment
+    import androidx.compose.ui.Modifier
+    import androidx.compose.ui.tooling.preview.Preview
+
+    // LIGHT SDK [Functions on Light Phone] //
+    import com.thelightphone.sdk.InitialScreen
+    import com.thelightphone.sdk.SealedLightActivity
+    import com.thelightphone.sdk.SimpleLightScreen
+    import com.thelightphone.sdk.ui.*
+
+    // COROUTINE [Allows events to occur over time] //
+    import kotlinx.coroutines.delay
+    import kotlinx.coroutines.launch
+
+// ----- SCREEN ----- // [This creates the actual screen the User will see.]
+@InitialScreen
+class SleepTrainerHomeScreen(sealedActivity: SealedLightActivity) :
+    SimpleLightScreen<Unit>(sealedActivity) {
+
+    // CONTENT FUNCTION ["Draws" everything the User sees] //
+    @Composable
+    override fun Content() {
+        val scope = rememberCoroutineScope()
+
+        // ----- APP MEMORY ----- //
+        var currentIntervalIndex by remember { mutableStateOf(0) }
+            // "Which Ferber interval am I currently on?" //
+        var timeLeftSeconds by remember { mutableStateOf(FerberSchedule.getIntervalMinutes(0) * 60) }
+            // "How many seconds are left in THIS interval?" //
+        var isRunning by remember { mutableStateOf(false) }
+            // "Is the timer currently running?" //
+        var isWaitingForNext by remember { mutableStateOf(false) }
+            // "Has an interval ended, and are we waiting for the user to start the next one?" //
+        var sessionTotalSeconds by remember { mutableStateOf(0) }
+            // "How long has the TOTAL session been (all intervals combined)?" //
+        var intervalsCompleted by remember { mutableStateOf(0) }
+            // "How many intervals has the user finished?" //
+
+        var history by remember { mutableStateOf<List<SessionData>>(emptyList()) }
+
+        // ----- LOAD HISTORY ----- //
+        LaunchedEffect(Unit) {
+            history = HistoryRepository.loadHistory(lightContext.dataStore)
+        }
+
+        // ----- TIMER LOGIC ----- //
+        LaunchedEffect(isRunning, timeLeftSeconds) {
+            if (isRunning && timeLeftSeconds > 0) {
+                delay(1000)
+                timeLeftSeconds--
+                sessionTotalSeconds++
+            }
+
+            if (isRunning && timeLeftSeconds == 0) {
+                isRunning = false
+                isWaitingForNext = true
+                intervalsCompleted++
+                
+                // ----- VIBRATION ----- //
+                lightContext.vibrate(500)
+            }
+        }
+
+        SleepTrainerHomeContent(
+            currentIntervalIndex = currentIntervalIndex,
+            timeLeftSeconds = timeLeftSeconds,
+            isRunning = isRunning,
+            isWaitingForNext = isWaitingForNext,
+            history = history,
+            onToggleTimer = {
+                if (isRunning || isWaitingForNext) {
+                    // This is actually the "STOP" button logic
+                    val total = sessionTotalSeconds
+                    val completed = intervalsCompleted
+                    scope.launch {
+                        HistoryRepository.saveSession(lightContext.dataStore, total, completed)
+                        
+                        // Reset all local session states
+                        isRunning = false
+                        isWaitingForNext = false
+                        currentIntervalIndex = 0
+                        timeLeftSeconds = FerberSchedule.getIntervalMinutes(0) * 60
+                        sessionTotalSeconds = 0
+                        intervalsCompleted = 0
+                        
+                        // Show the summary screen
+                        navigateTo({ SleepTrainerSummaryScreen(it, total, completed) })
+                    }
+                } else {
+                    // START
+                    isRunning = true
+                }
+            },
+            onNextInterval = {
+                currentIntervalIndex++
+                timeLeftSeconds = FerberSchedule.getIntervalMinutes(currentIntervalIndex) * 60
+                isWaitingForNext = false
+                isRunning = true
+            },
+            onViewHistory = {
+                navigateTo(::SleepTrainerHistoryScreen)
+            }
+        )
+    }
+}
+
+@Composable
+fun SleepTrainerHomeContent(
+    currentIntervalIndex: Int,
+    timeLeftSeconds: Int,
+    isRunning: Boolean,
+    isWaitingForNext: Boolean,
+    history: List<SessionData>,
+    onToggleTimer: () -> Unit,
+    onNextInterval: () -> Unit,
+    onViewHistory: () -> Unit
+) {
+    val themeColors by LightThemeController.colors.collectAsState()
+    LightTheme(colors = themeColors) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(LightThemeTokens.colors.background),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            LightTopBar(
+                center = LightTopBarCenter.Text("Cozy Sleep"),
+                modifier = Modifier.padding(bottom = 2f.gridUnitsAsDp())
+            )
+
+            LightText(
+                text = "INTERVAL ${currentIntervalIndex + 1}",
+                variant = LightTextVariant.Detail
+            )
+
+            LightText(
+                text = if (isWaitingForNext) "00:00" else FerberSchedule.formatTime(timeLeftSeconds),
+                variant = LightTextVariant.Heading,
+                modifier = Modifier.padding(vertical = 1f.gridUnitsAsDp())
+            )
+
+            // MAIN BUTTON (START / STOP)
+            LightText(
+                text = if (isRunning || isWaitingForNext) "STOP" else "START",
+                variant = LightTextVariant.Subtitle,
+                modifier = Modifier
+                    .lightClickable { onToggleTimer() }
+                    .padding(1f.gridUnitsAsDp()),
+                maxLines = 1
+            )
+
+            // NEXT INTERVAL BUTTON (only shows when one ends)
+            if (isWaitingForNext) {
+                Spacer(modifier = Modifier.height(1f.gridUnitsAsDp()))
+                LightText(
+                    text = "NEXT INTERVAL",
+                    variant = LightTextVariant.Subtitle,
+                    modifier = Modifier
+                        .lightClickable { onNextInterval() }
+                        .padding(1f.gridUnitsAsDp()),
+                    maxLines = 1
+                )
+            }
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            if (history.isNotEmpty()) {
+                LightText(
+                    text = "HISTORY",
+                    variant = LightTextVariant.Detail,
+                    modifier = Modifier
+                        .lightClickable { onViewHistory() }
+                        .padding(bottom = 0.5f.gridUnitsAsDp())
+                )
+
+                history.take(3).forEach { session ->
+                    LightText(
+                        text = "${session.totalTimeSeconds / 60}m | ${session.date}",
+                        variant = LightTextVariant.Detail
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(1f.gridUnitsAsDp()))
+        }
+    }
+}
+
+@Preview(widthDp = 1080 / 3, heightDp = 1240 / 3, showBackground = true)
+@Composable
+fun SleepTrainerPreviewStart() {
+    SleepTrainerHomeContent(
+        currentIntervalIndex = 0,
+        timeLeftSeconds = 120,
+        isRunning = false,
+        isWaitingForNext = false,
+        history = emptyList(),
+        onToggleTimer = {},
+        onNextInterval = {},
+        onViewHistory = {}
+    )
+}
+
+@Preview(widthDp = 1080 / 3, heightDp = 1240 / 3, showBackground = true)
+@Composable
+fun SleepTrainerPreviewRunning() {
+    SleepTrainerHomeContent(
+        currentIntervalIndex = 1,
+        timeLeftSeconds = 45,
+        isRunning = true,
+        isWaitingForNext = false,
+        history = listOf(
+            SessionData(300, "Jul 29", 2),
+            SessionData(600, "Jul 29", 4)
+        ),
+        onToggleTimer = {},
+        onNextInterval = {},
+        onViewHistory = {}
+    )
+}
+
+@Preview(widthDp = 1080 / 3, heightDp = 1240 / 3, showBackground = true)
+@Composable
+fun SleepTrainerPreviewWaiting() {
+    SleepTrainerHomeContent(
+        currentIntervalIndex = 0,
+        timeLeftSeconds = 0,
+        isRunning = false,
+        isWaitingForNext = true,
+        history = emptyList(),
+        onToggleTimer = {},
+        onNextInterval = {},
+        onViewHistory = {}
+    )
+}

--- a/examples/cozy-sleep-trainer/src/main/kotlin/com/thelightphone/sleeptrainer/SleepTrainerSummaryScreen.kt
+++ b/examples/cozy-sleep-trainer/src/main/kotlin/com/thelightphone/sleeptrainer/SleepTrainerSummaryScreen.kt
@@ -1,0 +1,95 @@
+package com.thelightphone.sleeptrainer
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.thelightphone.sdk.SealedLightActivity
+import com.thelightphone.sdk.SimpleLightScreen
+import com.thelightphone.sdk.ui.*
+
+class SleepTrainerSummaryScreen(
+    sealedActivity: SealedLightActivity,
+    private val totalSeconds: Int,
+    private val intervalsCompleted: Int
+) : SimpleLightScreen<Unit>(sealedActivity) {
+
+    @Composable
+    override fun Content() {
+        SleepTrainerSummaryContent(
+            totalSeconds = totalSeconds,
+            intervalsCompleted = intervalsCompleted,
+            onDone = { goBack() }
+        )
+    }
+}
+
+@Composable
+fun SleepTrainerSummaryContent(
+    totalSeconds: Int,
+    intervalsCompleted: Int,
+    onDone: () -> Unit
+) {
+    val themeColors by LightThemeController.colors.collectAsState()
+
+    LightTheme(colors = themeColors) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(LightThemeTokens.colors.background),
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            LightTopBar(
+                center = LightTopBarCenter.Text("Session Summary"),
+                modifier = Modifier.padding(bottom = 2f.gridUnitsAsDp())
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            LightText(
+                text = "TOTAL TIME",
+                variant = LightTextVariant.Detail
+            )
+            LightText(
+                text = FerberSchedule.formatTime(totalSeconds),
+                variant = LightTextVariant.Heading,
+                modifier = Modifier.padding(bottom = 2f.gridUnitsAsDp())
+            )
+
+            LightText(
+                text = "INTERVALS COMPLETED",
+                variant = LightTextVariant.Detail
+            )
+            LightText(
+                text = "$intervalsCompleted",
+                variant = LightTextVariant.Heading
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            LightText(
+                text = "DONE",
+                variant = LightTextVariant.Subtitle,
+                modifier = Modifier
+                    .lightClickable { onDone() }
+                    .padding(1f.gridUnitsAsDp())
+            )
+
+            Spacer(modifier = Modifier.height(2f.gridUnitsAsDp()))
+        }
+    }
+}
+
+@Preview(widthDp = 1080 / 3, heightDp = 1240 / 3, showBackground = true)
+@Composable
+fun SleepTrainerSummaryPreview() {
+    SleepTrainerSummaryContent(
+        totalSeconds = 450,
+        intervalsCompleted = 3,
+        onDone = {}
+    )
+}

--- a/examples/cozy-sleep-trainer/src/test/kotlin/com/thelightphone/sleeptrainer/SleepTrainerLogicTest.kt
+++ b/examples/cozy-sleep-trainer/src/test/kotlin/com/thelightphone/sleeptrainer/SleepTrainerLogicTest.kt
@@ -1,0 +1,33 @@
+package com.thelightphone.sleeptrainer
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class SleepTrainerLogicTest {
+
+    @Test
+    fun `formatTime formats zero correctly`() {
+        assertEquals("00:00", FerberSchedule.formatTime(0))
+    }
+
+    @Test
+    fun `formatTime formats seconds correctly`() {
+        assertEquals("00:45", FerberSchedule.formatTime(45))
+    }
+
+    @Test
+    fun `formatTime formats minutes correctly`() {
+        assertEquals("01:00", FerberSchedule.formatTime(60))
+        assertEquals("02:30", FerberSchedule.formatTime(150))
+    }
+
+    @Test
+    fun `Ferber intervals follow Day 1 schedule then repeat 15`() {
+        assertEquals(2, FerberSchedule.getIntervalMinutes(0))
+        assertEquals(5, FerberSchedule.getIntervalMinutes(1))
+        assertEquals(10, FerberSchedule.getIntervalMinutes(2))
+        assertEquals(15, FerberSchedule.getIntervalMinutes(3))
+        assertEquals(15, FerberSchedule.getIntervalMinutes(4)) // Infinite 15
+        assertEquals(15, FerberSchedule.getIntervalMinutes(100)) // Infinite 15
+    }
+}

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/LightActivity.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/LightActivity.kt
@@ -2,6 +2,8 @@ package com.thelightphone.sdk
 
 import android.content.Context
 import android.os.Bundle
+import android.os.VibrationEffect
+import android.os.Vibrator
 import android.view.WindowManager
 import androidx.activity.ComponentActivity
 import androidx.activity.OnBackPressedCallback
@@ -135,6 +137,11 @@ class SealedLightContext(internal val androidContext: Context) {
     val dataStore: DataStore<Preferences> by lazy{ androidContext.dataStore }
     val filesDir: File by lazy{ androidContext.filesDir }
     val fileShare: LightFileShare by lazy { LightFileShare(androidContext) }
+
+    fun vibrate(millis: Long) {
+        val vibrator = androidContext.getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+        vibrator.vibrate(VibrationEffect.createOneShot(millis, VibrationEffect.DEFAULT_AMPLITUDE))
+    }
 }
 /**
  * Wrapper class to pass around an instance of LightActivity without exposing it to

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -47,3 +47,6 @@ include(":examples:weather")
 project(":examples:weather").projectDir = file("examples/weather")
 include(":examples:authenticator")
 project(":examples:authenticator").projectDir = file("examples/authenticator")
+
+include(":examples:cozy-sleep-trainer")
+project(":examples:cozy-sleep-trainer").projectDir = file("examples/cozy-sleep-trainer")


### PR DESCRIPTION
**Summary**

Adds a new `Cozy Sleep Trainer` example app demonstrating a simple sleep-training timer built with the Light SDK.

**Features**

* Ferber interval timer with progressive intervals
* Start/stop and next-interval controls
* Vibration notification when an interval completes
* Session summary
* Local session history using DataStore
* Basic unit tests for timer logic

**_SDK Change_**

Adds a small `vibrate()` helper to `SealedLightContext` so example applications can trigger device vibration.

**Testing**

* `./gradlew build` passes successfully
* Basic unit tests included for interval scheduling and time formatting
