### PR TITLE
feat: increase idle stop audio timeout to 15 min

### DIFF
--- a/docs/design_decisions/detached_audio.md
+++ b/docs/design_decisions/detached_audio.md
@@ -131,14 +131,14 @@ platform `MediaSession` separately and renders its own controls.
 ## Lifetime and idle stop
 
 Playing detached audio keeps the service alive after the tool releases its handle.
-A paused service must not retain its player and process forever, so the service starts a 60-second timer when both conditions hold:
+A paused service must not retain its player and process forever, so the service starts a 15-minute timer when both conditions hold:
 
 1. playback is not playing
 2. no tool holds the detached handle.
 
 Playback resuming or a handle opening cancels the timer. When it fires, the service stops itself and releases the session and player.
 The handle, rather than the number of connected controllers, is the liveness signal because it covers controller connection gaps and gives ownership one source of truth.
-The timeout governs abandoned paused playback, not active playback. A paused tool that still holds its player can resume after 60 seconds.
+The timeout governs abandoned paused playback, not active playback. A paused tool that still holds its player can resume after 15 minutes.
 
 ## Reconnecting
 

--- a/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudioService.kt
+++ b/sdk/client/src/main/kotlin/com/thelightphone/sdk/audio/LightAudioService.kt
@@ -143,4 +143,4 @@ internal class LightAudioService : MediaSessionService() {
 internal fun shouldStartIdleStop(isPlaying: Boolean, handleOpen: Boolean): Boolean =
     !isPlaying && !handleOpen
 
-internal const val IDLE_STOP_MS = 60_000L
+internal const val IDLE_STOP_MS = 15 * 60_000L


### PR DESCRIPTION
`IDLE_STOP` represents how long a detached media session stays alive if there are no controllers hooked to it. For instance, this affects how long the playback controls stay in the LightOS lock screen after a user pauses playback and locks their phone.

After testing, it was clear that my original 1 minute guess was way too low, so this PR raises it to 15 minutes.
